### PR TITLE
Filter on None in mzml

### DIFF
--- a/pmultiqc/main.py
+++ b/pmultiqc/main.py
@@ -43,6 +43,9 @@ def pmultiqc_plugin_execution_start():
     if 'quantms/mzML' not in config.sp:
         config.update_dict(config.sp, {'quantms/mzML': {'fn': '*.mzML', 'num_lines': 0}})
 
+    if 'quantms/mzml_info' not in config.sp:
+        config.update_dict(config.sp, {'quantms/mzml_info': {'fn': 'mzml_info.tsv', 'num_lines': 0}})
+
     if 'quantms/idXML' not in config.sp:
         config.update_dict(config.sp, {'quantms/idXML': {'fn': '*.idXML', 'num_lines': 0}})
 

--- a/pmultiqc/modules/quantms/histogram.py
+++ b/pmultiqc/modules/quantms/histogram.py
@@ -70,6 +70,9 @@ class Histogram:
         :param stack: The stack of bars to which the data belongs
         :type stack: str, optional
         '''
+        if value == None:
+            return
+            
         if self.plot_category == 1:
             if self.breaks:
                 if value < self.threshold:
@@ -88,6 +91,11 @@ class Histogram:
                         self.data[str(value)][stack] = 1
                     else:
                         self.data[str(value)] = {stack: 1}
+                # sort
+                if type(value) != str and not self.stacks:
+                    data_keys = [type(value)(i) for i in self.data.keys()]
+                    data_keys.sort()
+                    self.data = OrderedDict({str(i): {"total": self.data[str(i)]["total"]} for i in data_keys})
 
         elif self.plot_category == 2:
             self.breaks.sort()
@@ -131,8 +139,7 @@ class Histogram:
             total = sum(self.data.values())
             self.dict['data']['frequency'] = OrderedDict()
             self.dict['data']['percentage'] = OrderedDict()
-            keys = sorted(self.data)  # sort
-            for key in keys:
+            for key in self.data:
                 self.dict['data']['frequency'][key] = OrderedDict()
                 self.dict['data']['frequency'][key]['Frequency'] = self.data[key]
                 self.dict['data']['percentage'][key] = OrderedDict()

--- a/pmultiqc/modules/quantms/quantms.py
+++ b/pmultiqc/modules/quantms/quantms.py
@@ -97,6 +97,7 @@ class QuantMSModule(BaseMultiqcModule):
         self.mzml_peptide_map = dict()
         self.identified_spectrum = dict()
         self.pep_quant_table = dict()
+        self.read_mzml_info = False
         self.mzml_table = OrderedDict()
         self.search_engine = OrderedDict()
         self.XCORR_HIST_RANGE = {'start': 0, 'end': 5, 'step': 0.1}

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ For more information about MultiQC, see http://multiqc.info
 
 from setuptools import setup, find_packages
 
-version = '0.0.14'
+version = '0.0.15'
 
 
 def readme():


### PR DESCRIPTION
report before fixs: [outdated](https://github.com/WangHong007/Data-Folder/blob/458093414c30a5720b9dfe8d927cabe5118ae66e/pmultiqc/multiqc_report_outdated.html)
report after fixs: [new](https://github.com/WangHong007/Data-Folder/blob/458093414c30a5720b9dfe8d927cabe5118ae66e/pmultiqc/multiqc_report_new.html)

@ypriverol I tested the file where the problem occurs [quantms#224](https://github.com/bigbio/quantms/issues/224), the code now calculates peak intensities and also filters for `None`. DIA report here: [partial_dia](https://github.com/WangHong007/Data-Folder/blob/458093414c30a5720b9dfe8d927cabe5118ae66e/pmultiqc/dia_test_report.html)