### PR TITLE
:bug: use metadata module and order imports

### DIFF
--- a/pmultiqc/main.py
+++ b/pmultiqc/main.py
@@ -4,19 +4,25 @@ MultiQC pmultiqc plugin functions
 """
 
 from __future__ import print_function
-from pkg_resources import get_distribution
+
 import logging
+import os
+from importlib import metadata
+from pathlib import Path
+
 from multiqc import config
 
-from pathlib import Path
-import os
-from pmultiqc.modules.common.file_utils import is_archive_file, extract_archive_file, get_clean_stem
+from pmultiqc.modules.common.file_utils import (
+    extract_archive_file,
+    get_clean_stem,
+    is_archive_file,
+)
 
 # Initialise the main MultiQC logger
 log = logging.getLogger("pmultiqc")
 
 # Save this plugin's version number (defined in setup.py) to the MultiQC config
-config.pmultiqc_version = get_distribution("pmultiqc").version
+config.pmultiqc_version = metadata.version("pmultiqc")
 
 
 # Add default config options for the things that are used in MultiQC_NGI


### PR DESCRIPTION
### **User description**
Now it is still now working as you restrict the numpy version to a pinned version:

```bash
Collecting numpy==1.24.3 (from pmultiqc==0.0.29)
  Using cached numpy-1.24.3.tar.gz (10.9 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [33 lines of output]
      Traceback (most recent call last):
        File "/Users/heweb/miniforge3/envs/nextflow/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/Users/heweb/miniforge3/envs/nextflow/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/heweb/miniforge3/envs/nextflow/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 112, in get_requires_for_build_wheel
          backend = _build_backend()
                    ^^^^^^^^^^^^^^^^
        File "/Users/heweb/miniforge3/envs/nextflow/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 77, in _build_backend
          obj = import_module(mod_path)
                ^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/heweb/miniforge3/envs/nextflow/lib/python3.12/importlib/__init__.py", line 90, in import_module
          return _bootstrap._gcd_import(name[level:], package, level)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
        File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
        File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
        File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
        File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
        File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
        File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
        File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
        File "<frozen importlib._bootstrap_external>", line 995, in exec_module
        File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
        File "/private/var/folders/l5/nswv371n67s9yhyshhkmwm140000gp/T/pip-build-env-l_2srbw1/overlay/lib/python3.12/site-packages/setuptools/__init__.py", line 16, in <module>
          import setuptools.version
        File "/private/var/folders/l5/nswv371n67s9yhyshhkmwm140000gp/T/pip-build-env-l_2srbw1/overlay/lib/python3.12/site-packages/setuptools/version.py", line 1, in <module>
          import pkg_resources
        File "/private/var/folders/l5/nswv371n67s9yhyshhkmwm140000gp/T/pip-build-env-l_2srbw1/overlay/lib/python3.12/site-packages/pkg_resources/__init__.py", line 2172, in <module>
          register_finder(pkgutil.ImpImporter, find_on_path)
                          ^^^^^^^^^^^^^^^^^^^
      AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```


___

### **PR Type**
Bug fix


___

### **Description**
- Replace deprecated `pkg_resources` with `importlib.metadata`

- Reorganize imports following Python conventions

- Fix version retrieval for better Python 3.12 compatibility


___

### **Changes diagram**

```mermaid
flowchart LR
  A["pkg_resources.get_distribution"] --> B["importlib.metadata.version"]
  C["Mixed import order"] --> D["Organized imports by type"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Modernize imports and fix deprecated package usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pmultiqc/main.py

<li>Replace <code>pkg_resources.get_distribution()</code> with <code>metadata.version()</code><br> <li> Reorganize imports into standard library, third-party, and local <br>groups<br> <li> Add proper import grouping with blank lines<br> <li> Alphabetize imports within the file_utils import group


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/206/files#diff-7f08ab4a1de6cb6ade4df55c6525dd5624ac8c69a47a4ed770b040429d795dfb">+11/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of version retrieval for the plugin. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->