### PR TITLE
MaxQuant: Fix NaN intensity errors

### DIFF
--- a/pmultiqc/modules/maxquant/maxquant_utils.py
+++ b/pmultiqc/modules/maxquant/maxquant_utils.py
@@ -448,7 +448,7 @@ def get_evidence(file_path):
     Returns:
         Dictionary containing various metrics extracted from the evidence file
     """
-    mq_data = read(file_path, filter_type="Reverse")
+    mq_data = read(file_path, file_type = "evidence", filter_type="Reverse")
 
     # Count peptides and MS/MS spectra
     total_entries = len(mq_data)
@@ -582,11 +582,14 @@ def calculate_heatmap(evidence_df, oversampling, msms_missed_cleavages):
         ].groupby("raw file"):
 
         # 1. Contaminants
-        contaminant = 1 - (group[group["potential contaminant"] == "+"]["intensity"].sum() 
-                           / group["intensity"].sum())
-        
+        intensity_contaminant = group[group["potential contaminant"] == "+"]["intensity"].sum()
+        intensity_all = group["intensity"].sum()
+        if np.isnan(intensity_contaminant) or np.isnan(intensity_all) or intensity_all == 0:
+            contaminant = 1
+        else:
+            contaminant = 1 - intensity_contaminant / intensity_all
+
         # 2. Peptide Intensity
-        peptide_intensity = np.minimum(1.0, np.nanmedian(group["intensity"]) / (2**23))
         peptide_intensity = np.fmin(1.0, np.nanmedian(group["intensity"])) / (2**23) ## np.fmin does not propagate NaN's
 
         # 8. Pep Missing Values
@@ -710,7 +713,7 @@ def evidence_top_contaminants(evidence_df, top_n):
         intensity_per_file_protein["contaminant_intensity"]
         / intensity_per_file_protein["total_intensity"]
         * 100
-    )
+    ).replace([np.nan], 1)  ## total_intensity may be 0, which produces NaN (so we judge contaminants not to be an issue -> score 1)
 
     top_contaminant_dict = {}
 

--- a/pmultiqc/modules/maxquant/maxquant_utils.py
+++ b/pmultiqc/modules/maxquant/maxquant_utils.py
@@ -587,6 +587,7 @@ def calculate_heatmap(evidence_df, oversampling, msms_missed_cleavages):
         
         # 2. Peptide Intensity
         peptide_intensity = np.minimum(1.0, np.nanmedian(group["intensity"]) / (2**23))
+        peptide_intensity = np.fmin(1.0, np.nanmedian(group["intensity"])) / (2**23) ## np.fmin does not propagate NaN's
 
         # 8. Pep Missing Values
         pep_missing_values = np.minimum(


### PR DESCRIPTION
### **User description**
for some datasets with NaN in intensity columns of evidence.txt, pmultiqc would fail with errors when plotting due to NaNs

This fixes it.

However, there are quite some more issues to address. Currently only 32 of my 64 MaxQuant datasets produce reports.
I will continue working on it after holidays :)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix NaN intensity errors in MaxQuant evidence processing

- Handle division by zero in contaminant calculations

- Prevent NaN propagation in peptide intensity computations

- Replace NaN values with appropriate defaults in percentage calculations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Evidence Data"] --> B["Contaminant Calculation"]
  A --> C["Peptide Intensity"]
  A --> D["Intensity Percentage"]
  B --> E["NaN/Zero Check"]
  C --> F["fmin Function"]
  D --> G["NaN Replacement"]
  E --> H["Fixed Output"]
  F --> H
  G --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>maxquant_utils.py</strong><dd><code>Fix NaN handling in MaxQuant evidence processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pmultiqc/modules/maxquant/maxquant_utils.py

<ul><li>Add file_type parameter to <code>read()</code> function call<br> <li> Implement NaN and zero division checks in contaminant calculations<br> <li> Replace <code>np.minimum</code> with <code>np.fmin</code> to prevent NaN propagation<br> <li> Add NaN replacement with default value 1 in intensity percentage <br>calculations</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/304/files#diff-1e0b09780abe9f59cf2285cdf491e004ddcdf4d4542f694b1b1e4260b9b9e031">+10/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured correct parsing of evidence files by explicitly specifying the file type.
  * Resolved NaN and zero-division issues in heatmap calculations; contaminants ratio and peptide intensity are now robust and properly bounded.
  * Prevented NaN percentages in top contaminants when total intensity is zero, ensuring reliable containment metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->