### PR TITLE
minor update

### DIFF
--- a/pmultiqc/modules/maxquant/maxquant_utils.py
+++ b/pmultiqc/modules/maxquant/maxquant_utils.py
@@ -597,7 +597,8 @@ def calculate_heatmap(evidence_df, oversampling, msms_missed_cleavages):
             contaminant = 1 - intensity_contaminant / intensity_all
 
         # 2. Peptide Intensity
-        peptide_intensity = np.fmin(1.0, np.nanmedian(group["intensity"])) / (2**23) ## np.fmin does not propagate NaN's
+        median_int = np.fmax(0, np.nanmedian(group["intensity"]))  ## if everything is NaN, take 0 (np.fmax ignores NaN)
+        peptide_intensity = np.minimum(1.0, median_int / (2**23)) ## score = 1, iff intensity >= 2**23
 
         # 8. Pep Missing Values
         pep_missing_values = np.minimum(


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix intensity score calculation when all values are NaN

- Replace `np.fmin` with `np.fmax` to handle NaN cases properly

- Update peptide intensity calculation logic for edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NaN intensity values"] --> B["np.fmax(0, np.nanmedian)"]
  B --> C["peptide_intensity calculation"]
  C --> D["Fixed intensity score"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>maxquant_utils.py</strong><dd><code>Fix NaN handling in peptide intensity calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pmultiqc/modules/maxquant/maxquant_utils.py

<ul><li>Replace <code>np.fmin</code> with <code>np.fmax</code> to handle NaN values<br> <li> Add intermediate <code>median_int</code> variable for clarity<br> <li> Update peptide intensity calculation to use <code>np.minimum</code></ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/336/files#diff-1e0b09780abe9f59cf2285cdf491e004ddcdf4d4542f694b1b1e4260b9b9e031">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

