### PR TITLE
elaborate modification table

### DIFF
--- a/pmultiqc/modules/common/common_plots.py
+++ b/pmultiqc/modules/common/common_plots.py
@@ -181,7 +181,7 @@ def draw_modifications(sub_section, modified_data):
         plot=bar_html,
         order=6,
         description="""
-            Compute an occurence table of modifications (e.g. Oxidation (M)) for all peptides, including the unmodified (but without contaminants).
+            Compute an occurrence table of modifications (e.g. Oxidation (M)) for all peptides, including the unmodified (but without contaminants).
             """,
         helptext="""
 Post-translational modifications contained within the identified peptide sequence.<br>


### PR DESCRIPTION
### **User description**
when comparing PTXQC and pmultiqc results, I found a discrepancy in the `Modifications Per Raw File` plots.
The reason is simple: PTXQC includes contaminants, pmultiqc does not.
Both are arguably valid.

This PR adds some docs on what is plotted (taken from the PTXQC docs).


___

### **PR Type**
Documentation


___

### **Description**
- Enhanced modification table documentation with detailed explanations

- Added clarification about contaminant exclusion

- Included concrete example with percentage calculations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original docs"] --> B["Enhanced description"]
  B --> C["Detailed helptext"]
  C --> D["Concrete example"]
  D --> E["Clarified contaminant handling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common_plots.py</strong><dd><code>Enhanced modification table documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pmultiqc/modules/common/common_plots.py

<ul><li>Updated description to clarify contaminants are excluded<br> <li> Expanded helptext with detailed explanation of modification frequency <br>calculation<br> <li> Added concrete example showing how percentages are computed<br> <li> Clarified that multiple modifications in single peptide are counted <br>separately</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/363/files#diff-7b8c3c5158a74e24ece003c5ede741e5f3de2d474b4b3076b1e648c4a2f933c7">+22/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

