### PR TITLE
Minor changes in the FragPipe support

### DIFF
--- a/pmultiqc/modules/common/plots/dia.py
+++ b/pmultiqc/modules/common/plots/dia.py
@@ -153,9 +153,9 @@ def draw_dia_ms1_area(sub_section, df):
         "id": "ms1_area_distribution_box",
         "cpswitch": False,
         "cpswitch_c_active": False,
-        "title": "Ms1 Area Distribution",
+        "title": "MS1 Area Distribution",
         "tt_decimals": 5,
-        "xlab": "log2(Ms1.Area)",
+        "xlab": "log2(MS1.Area)",
         "save_data_file": False,
     }
 
@@ -210,7 +210,7 @@ def draw_dia_whole_exp_charge(sub_section, df):
     add_sub_section(
         sub_section=sub_section,
         plot=bar_html,
-        order=5,
+        order=3,
         description="""
             This is a bar chart representing the distribution of the precursor ion charges for a given whole experiment.
         """,
@@ -269,7 +269,7 @@ def draw_dia_ms2_charge(sub_section, df, sdrf_file_df):
     add_sub_section(
         sub_section=sub_section,
         plot=bar_html,
-        order=6,
+        order=4,
         description="The distribution of the charge-state of the precursor ion.",
         helptext="""
             [DIA-NN: main report] The distribution of the charge-state of the precursor ion (Precursor.Charge).

--- a/pmultiqc/modules/common/plots/id.py
+++ b/pmultiqc/modules/common/plots/id.py
@@ -1124,7 +1124,7 @@ def draw_peptide_intensity(sub_section, plot_data):
             """,
     )
 
-def draw_long_trends(sub_section, long_trends_data):
+def draw_long_trends(sub_sections, long_trends_data):
 
     plot_ac_datetime = long_trends_data["time"]
     plot_rt = long_trends_data["rt"]
@@ -1133,33 +1133,33 @@ def draw_long_trends(sub_section, long_trends_data):
 
     if plot_ac_datetime:
         draw_filename_datetime_table(
-            sub_section=sub_section,
+            sub_sections=sub_sections,
             ac_datetime=plot_ac_datetime
         )
 
     if plot_rt:
         draw_long_trends_linegraph(
-            sub_section=sub_section,
+            sub_sections=sub_sections,
             plot_data=plot_rt,
             report_type="rt"
         )
 
     if plot_ms1_summed_intensity:
         draw_long_trends_linegraph(
-            sub_section=sub_section,
+            sub_sections=sub_sections,
             plot_data=plot_ms1_summed_intensity,
             report_type="ms1_summed_intensity"
         )
 
     if plot_ms2_prec_intensity:
         draw_long_trends_linegraph(
-            sub_section=sub_section,
+            sub_sections=sub_sections,
             plot_data=plot_ms2_prec_intensity,
             report_type="ms2_prec_intensity"
         )
 
 
-def draw_filename_datetime_table(sub_section, ac_datetime: dict):
+def draw_filename_datetime_table(sub_sections, ac_datetime: dict):
 
     ac_datetime_data = dict(
         sorted(ac_datetime.items(), key=lambda x: x[1]["acquisition_datetime"])
@@ -1187,9 +1187,9 @@ def draw_filename_datetime_table(sub_section, ac_datetime: dict):
     table_html = table.plot(data=ac_datetime_data, headers=headers, pconfig=draw_config)
 
     add_sub_section(
-        sub_section=sub_section,
+        sub_section=sub_sections["summary"],
         plot=table_html,
-        order=1,
+        order=4,
         description="",
         helptext="""
             This table provides the mapping between file names and their corresponding acquisition times.
@@ -1197,7 +1197,7 @@ def draw_filename_datetime_table(sub_section, ac_datetime: dict):
     )
 
 
-def draw_long_trends_linegraph(sub_section, plot_data: dict, report_type: str):
+def draw_long_trends_linegraph(sub_sections, plot_data: dict, report_type: str):
 
     plot_data = dict(sorted(plot_data.items(), key=lambda item: item[0]))
 
@@ -1205,7 +1205,7 @@ def draw_long_trends_linegraph(sub_section, plot_data: dict, report_type: str):
         "data": plot_data
     }
 
-    plot_config = {
+    plot_configs = {
         "rt": {
             "id": "longitudinal_trends_rt",
             "title": "MS1 Retention Time Trend",
@@ -1218,7 +1218,8 @@ def draw_long_trends_linegraph(sub_section, plot_data: dict, report_type: str):
                 This plot tracks LC stability by extracting RTs from all ms_level: 1 spectra.
                 For each run, the median RT is calculated as a robust representative value and plotted chronologically by acquisition datetime.
                 """,
-            "order": 4,
+            "sub_section": "rt_qc",
+            "order": 6,
         },
         "ms1_summed_intensity": {
             "id": "ms1_tic_proxy",
@@ -1233,7 +1234,8 @@ def draw_long_trends_linegraph(sub_section, plot_data: dict, report_type: str):
                 For each run, the summed_peak_intensities from all ms_level: 1 spectra are extracted.
                 The median value is calculated and log2-transformed to provide a robust representative of the Total Ion Current (TIC) per run.
                 """,
-            "order": 2,
+            "sub_section": "ms1",
+            "order": 6,
         },
         "ms2_prec_intensity": {
             "id": "ms2_precursor_intensity_trend",
@@ -1247,17 +1249,19 @@ def draw_long_trends_linegraph(sub_section, plot_data: dict, report_type: str):
                 This plot tracks instrument sensitivity by extracting intensities from all ms_level: 2 precursor ions.
                 For each run, the median intensity is calculated as a robust representative value and plotted chronologically by acquisition datetime.
                 """,
-            "order": 3,
+            "sub_section": "ms2",
+            "order": 7,
         },
     }
 
-    log.info(f"Generating: {plot_config[report_type]['title']}")
+    plot_config = plot_configs[report_type]
+    log.info(f"Generating: {plot_config['title']}")
 
     draw_config = {
-        "id": plot_config[report_type]["id"],
-        "title": plot_config[report_type]["title"],
-        "xlab": plot_config[report_type]["xlab"],
-        "ylab": plot_config[report_type]["ylab"],
+        "id": plot_config["id"],
+        "title": plot_config["title"],
+        "xlab": plot_config["xlab"],
+        "ylab": plot_config["ylab"],
         "cpswitch": False,
         "cpswitch_c_active": False,
         "ymax": max(plot_data.values()) + 1,
@@ -1274,9 +1278,9 @@ def draw_long_trends_linegraph(sub_section, plot_data: dict, report_type: str):
     linegraph_html = plot_html_check(linegraph_html)
 
     add_sub_section(
-        sub_section=sub_section,
+        sub_section=sub_sections[plot_config["sub_section"]],
         plot=linegraph_html,
-        order=plot_config[report_type]["order"],
-        description=plot_config[report_type]["description"],
-        helptext=plot_config[report_type]["helptext"],
+        order=plot_config["order"],
+        description=plot_config["description"],
+        helptext=plot_config["helptext"],
     )

--- a/pmultiqc/modules/core/core.py
+++ b/pmultiqc/modules/core/core.py
@@ -64,7 +64,6 @@ class PMultiQC(BaseMultiqcModule):
             "ms2": [],
             "mass_error": [],
             "rt_qc": [],
-            "long_trends": [],
         }
 
         if config.kwargs.get("disable_hoverinfo", False):

--- a/pmultiqc/modules/core/section_groups.py
+++ b/pmultiqc/modules/core/section_groups.py
@@ -167,12 +167,6 @@ def add_group_modules(groups_dict, analysis_type):
                 "name": "RT Quality Control",
                 "description": "",
             },
-            {
-                "id": "longitudinal_trends",
-                "key": "long_trends_sub_section",
-                "name": "Longitudinal Trends",
-                "description": "",
-            },
         ]
 
     for group in group_configs:
@@ -190,39 +184,52 @@ def add_group_modules(groups_dict, analysis_type):
 
     if analysis_type == "proteobench":
 
-        config.report_section_order = {
-            "pmultiqc": {"order": 6},
-            "precursor_ion": {"order": 5},
-            "intensity": {"order": 4},
-            "std_intensity": {"order": 3},
-            "cv": {"order": 2},
-            "log_vs": {"order": 1},
-        }
+        # Note: this is the order required for the report.
+        report_sections = [
+            "pmultiqc",
+            "precursor_ion",
+            "intensity",
+            "std_intensity",
+            "cv",
+            "log_vs"
+        ]
 
     else:
-        config.report_section_order = {
-            "pmultiqc": {"order": 21},
-            "experiment_setup": {"order": 20},
-            "summary_and_heatmap": {"order": 19},
-            "identification_summary": {"order": 18},
-            "search_engine_scores": {"order": 17},
-            "contaminants": {"order": 16},
-            "quantification_analysis": {"order": 15},
-            "ms1_analysis": {"order": 14},
-            "ms2_and_spectral_stats": {"order": 13},
-            "mass_error_trends": {"order": 12},
-            "rt_quality_control": {"order": 11},
-            "longitudinal_trends": {"order": 10},
-            "software_versions": {"order": 9},
-            "multiqc_software_versions": {"order": 8},
-            "nf_core_quantms_software": {"order": 7},
-            "nf-core-quantms-summary": {"order": 6},
-            "workflow_summary": {"order": 5},
-            "bigbio-quantms-summary": {"order": 4},
-            "bigbio-quantms-methods-description": {"order": 3},
-            "nf-core-quantms-methods-description": {"order": 2},
-            "methods_description": {"order": 1},
-        }
+        # Note: this is the order required for the report.
+        report_sections = [
+            "pmultiqc",
+            "experiment_setup",
+            "summary_and_heatmap",
+            "identification_summary",
+            "search_engine_scores",
+            "contaminants",
+            "quantification_analysis",
+            "ms1_analysis",
+            "ms2_and_spectral_stats",
+            "mass_error_trends",
+            "rt_quality_control",
+            "software_versions",
+            "multiqc_software_versions",
+            "nf_core_quantms_software",
+            "nf-core-quantms-summary",
+            "workflow_summary",
+            "bigbio-quantms-summary",
+            "bigbio-quantms-methods-description",
+            "nf-core-quantms-methods-description",
+            "methods_description"
+        ]
+
+    config.report_section_order = generate_section_order(report_sections)
+
+
+def generate_section_order(section_list: list):
+
+    section_order = {
+        name: {"order": len(section_list) - i}
+        for i, name in enumerate(section_list)
+    }
+
+    return section_order
 
 
 # Function of add sub_section

--- a/pmultiqc/modules/diann/diann.py
+++ b/pmultiqc/modules/diann/diann.py
@@ -209,7 +209,7 @@ class DiannModule(BasePMultiqcModule):
 
         if self.long_trends:
             draw_long_trends(
-                sub_section=self.sub_sections["long_trends"],
+                sub_sections=self.sub_sections,
                 long_trends_data=self.long_trends
             )
 
@@ -227,7 +227,6 @@ class DiannModule(BasePMultiqcModule):
             "ms2_sub_section": self.sub_sections["ms2"],
             "mass_error_sub_section": self.sub_sections["mass_error"],
             "rt_qc_sub_section": self.sub_sections["rt_qc"],
-            "long_trends_sub_section": self.sub_sections["long_trends"],
         }
 
         add_group_modules(self.section_group_dict, "")

--- a/pmultiqc/modules/maxquant/maxquant_plots.py
+++ b/pmultiqc/modules/maxquant/maxquant_plots.py
@@ -721,7 +721,7 @@ def draw_msms_scans_top_n(sub_section, top_n_data):
     add_sub_section(
         sub_section=sub_section,
         plot=bar_html,
-        order=9,
+        order=5,
         description='This metric somewhat summarizes "TopN over RT"',
         helptext="""
             Reaching TopN on a regular basis indicates that all sections of the LC gradient
@@ -753,7 +753,7 @@ def draw_msms_scans_top_over_rt(sub_section, top_over_rt_data):
     add_sub_section(
         sub_section=sub_section,
         plot=linegraph_html,
-        order=8,
+        order=4,
         description="TopN over retention time.",
         helptext="""
             TopN over retention time. Similar to ID over RT, this metric reflects the complexity of the sample
@@ -786,7 +786,7 @@ def draw_msms_scans_ion_injec_time_rt(sub_section, ion_injec_time_rt_data):
     add_sub_section(
         sub_section=sub_section,
         plot=linegraph_html,
-        order=7,
+        order=3,
         description="",
         helptext="""
             Ion injection time score - should be as low as possible to allow fast cycles. Correlated with peptide intensity.

--- a/pmultiqc/modules/mzidentml/mzidentml.py
+++ b/pmultiqc/modules/mzidentml/mzidentml.py
@@ -245,7 +245,7 @@ class MzIdentMLModule(BasePMultiqcModule):
 
         if self.long_trends:
             draw_long_trends(
-                sub_section=self.sub_sections["long_trends"],
+                sub_sections=self.sub_sections,
                 long_trends_data=self.long_trends
             )
 
@@ -260,7 +260,6 @@ class MzIdentMLModule(BasePMultiqcModule):
             "ms2_sub_section": self.sub_sections["ms2"],
             "mass_error_sub_section": self.sub_sections["mass_error"],
             "rt_qc_sub_section": self.sub_sections["rt_qc"],
-            "long_trends_sub_section": self.sub_sections["long_trends"],
         }
 
         add_group_modules(self.section_group_dict, "")

--- a/pmultiqc/modules/quantms/quantms.py
+++ b/pmultiqc/modules/quantms/quantms.py
@@ -472,7 +472,7 @@ class QuantMSModule(BasePMultiqcModule):
 
         if self.long_trends:
             draw_long_trends(
-                sub_section=self.sub_sections["long_trends"],
+                sub_sections=self.sub_sections,
                 long_trends_data=self.long_trends
             )
 
@@ -540,7 +540,6 @@ class QuantMSModule(BasePMultiqcModule):
             "ms2_sub_section": self.sub_sections["ms2"],
             "mass_error_sub_section": self.sub_sections["mass_error"],
             "rt_qc_sub_section": self.sub_sections["rt_qc"],
-            "long_trends_sub_section": self.sub_sections["long_trends"],
         }
 
         add_group_modules(self.section_group_dict, "")


### PR DESCRIPTION
### **User description**
# Pull Request

## Description

Brief description of the changes made in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test addition/update
- [ ] Updates to the dependencies has been done.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactor longitudinal trends to distribute plots across multiple subsections

- Remove dedicated "long_trends" section group and integrate into existing sections

- Fix capitalization of MS1 labels in DIA plots

- Optimize plot ordering and section structure for better report organization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Longitudinal Trends Function"] -->|"Refactored to accept"| B["Multiple Sub-sections"]
  B -->|"Distributes plots to"| C["RT QC Section"]
  B -->|"Distributes plots to"| D["MS1 Section"]
  B -->|"Distributes plots to"| E["MS2 Section"]
  B -->|"Distributes plots to"| F["Summary Section"]
  G["Remove long_trends Section"] -->|"Eliminates"| H["Dedicated Group Module"]
  I["Update Section Ordering"] -->|"Simplifies"| J["Report Configuration"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dia.py</strong><dd><code>Fix MS1 capitalization and adjust plot ordering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pmultiqc/modules/common/plots/dia.py

<ul><li>Fix capitalization: "Ms1" → "MS1" in title and axis label<br> <li> Adjust plot ordering: change order from 5 to 3 for whole experiment <br>charge<br> <li> Adjust plot ordering: change order from 6 to 4 for MS2 charge <br>distribution</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/520/files#diff-03ed6d774a65647bd6dd990ad8aa9137b4fbdfed27056f0f8c89ab2b84f8f5a7">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>id.py</strong><dd><code>Refactor longitudinal trends to multi-subsection distribution</code></dd></summary>
<hr>

pmultiqc/modules/common/plots/id.py

<ul><li>Refactor <code>draw_long_trends()</code> to accept <code>sub_sections</code> dict instead of <br>single <code>sub_section</code><br> <li> Refactor <code>draw_filename_datetime_table()</code> to use <code>sub_sections["summary"]</code> <br>and adjust order to 4<br> <li> Refactor <code>draw_long_trends_linegraph()</code> to distribute plots across <br>multiple subsections (rt_qc, ms1, ms2)<br> <li> Restructure plot configuration to use <code>plot_configs</code> dict with <br>sub_section mapping and updated ordering<br> <li> Simplify config access by extracting single plot_config from <br>plot_configs dict</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/520/files#diff-7d9005fc6e92866daa0a2f5d48a25653c021112b88b4d12647ebfb7585ec2ee7">+26/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>core.py</strong><dd><code>Remove long_trends subsection initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pmultiqc/modules/core/core.py

- Remove "long_trends" from sub_sections dictionary initialization


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/520/files#diff-97217850b89f35cb2401fb60568686d218dbf65eeb490aa5dd17f6678f59d04c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>section_groups.py</strong><dd><code>Remove long_trends group and refactor section ordering</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pmultiqc/modules/core/section_groups.py

<ul><li>Remove "longitudinal_trends" section group configuration entirely<br> <li> Refactor report section ordering from dict format to list-based <br>approach<br> <li> Add <code>generate_section_order()</code> helper function to dynamically compute <br>section ordering<br> <li> Update both proteobench and default analysis type section orderings</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/520/files#diff-3ab673db282f98e333fdd55b5c96631831e2c20af20319f49921df7d36a15f13">+44/-37</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>diann.py</strong><dd><code>Update long_trends function call and remove section reference</code></dd></summary>
<hr>

pmultiqc/modules/diann/diann.py

<ul><li>Update <code>draw_long_trends()</code> call to pass <code>self.sub_sections</code> dict instead <br>of <code>self.sub_sections["long_trends"]</code><br> <li> Remove "long_trends_sub_section" from section_group_dict</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/520/files#diff-80e05644997cd004e81e9c5c165baeda351bb242463e0fa6f7684c86133771ef">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>maxquant_plots.py</strong><dd><code>Optimize MaxQuant plot ordering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pmultiqc/modules/maxquant/maxquant_plots.py

<ul><li>Adjust plot ordering in <code>draw_msms_scans_top_n()</code>: order 9 → 5<br> <li> Adjust plot ordering in <code>draw_msms_scans_top_over_rt()</code>: order 8 → 4<br> <li> Adjust plot ordering in <code>draw_msms_scans_ion_injec_time_rt()</code>: order 7 → <br>3</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/520/files#diff-6f3e4d8a1f3191fa44daaa84e67965ff685fdacb17bbee262d0ff04d0e9b2b2f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mzidentml.py</strong><dd><code>Update long_trends function call and remove section reference</code></dd></summary>
<hr>

pmultiqc/modules/mzidentml/mzidentml.py

<ul><li>Update <code>draw_long_trends()</code> call to pass <code>self.sub_sections</code> dict instead <br>of <code>self.sub_sections["long_trends"]</code><br> <li> Remove "long_trends_sub_section" from section_group_dict</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/520/files#diff-521d6ccf304711175dd36099a5bbd8d9203b4eb6d6768e61725aea389fa38319">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>quantms.py</strong><dd><code>Update long_trends function call and remove section reference</code></dd></summary>
<hr>

pmultiqc/modules/quantms/quantms.py

<ul><li>Update <code>draw_long_trends()</code> call to pass <code>self.sub_sections</code> dict instead <br>of <code>self.sub_sections["long_trends"]</code><br> <li> Remove "long_trends_sub_section" from section_group_dict</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/520/files#diff-323554ae94c87cadce4761140cbc34fe7c6f38194405c59045e83996c359fb59">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Corrected capitalization in MS1 Area Distribution plot labels ("Ms1" → "MS1")

## Refactor
- Reorganized plot ordering across multiple analysis modules for improved report layout
- Streamlined report section organization by removing Longitudinal Trends group and restructuring section ordering

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->