### PR TITLE
Claude Review codebase for performance and bugs

### DIFF
--- a/pmultiqc/modules/common/common_utils.py
+++ b/pmultiqc/modules/common/common_utils.py
@@ -329,7 +329,7 @@ def evidence_rt_count(evidence_data):
 
 def evidence_calibrated_mass_error(
     evidence_data,
-    recommpute=False,
+    recompute=False,
     filter_outliers_ppm: bool = False
 ):
     # filter_outliers_ppm (if True): Remove rows with mass error [ppm] greater than 1000 (Default: False)
@@ -337,8 +337,8 @@ def evidence_calibrated_mass_error(
     if "potential contaminant" in evidence_data.columns:
         evidence_data = evidence_data[evidence_data["potential contaminant"] != "+"].copy()
 
-    if recommpute:
-        evd_df = recommpute_mass_error(evidence_data)
+    if recompute:
+        evd_df = recompute_mass_error(evidence_data)
     else:
         evd_df = evidence_data.copy()
 
@@ -395,7 +395,7 @@ def evidence_calibrated_mass_error(
     return result_dict
 
 # re-compute mass error
-def recommpute_mass_error(evidence_df):
+def recompute_mass_error(evidence_df):
     required_cols = [
         "mass error [ppm]",
         "uncalibrated mass error [ppm]",

--- a/pmultiqc/modules/common/ms/msinfo.py
+++ b/pmultiqc/modules/common/ms/msinfo.py
@@ -139,11 +139,11 @@ class MsInfoReader(BaseParser):
                 self.enable_dia,
             )
 
-            for m in mzml_table.keys():
-                if mzml_table[m]["MS2_Num"] > 0:
-                    heatmap_charge[m] = mzml_table[m]["Charge_2"] / mzml_table[m]["MS2_Num"]
-                else:
-                    heatmap_charge[m] = 0
+            # Calculate heatmap_charge only for current file (not all files in each iteration)
+            if mzml_table[m_name]["MS2_Num"] > 0:
+                heatmap_charge[m_name] = mzml_table[m_name]["Charge_2"] / mzml_table[m_name]["MS2_Num"]
+            else:
+                heatmap_charge[m_name] = 0
 
             self.log.info(
                 "{}: Done aggregating ms_statistics dataframe {}...".format(

--- a/pmultiqc/modules/common/plots/dia.py
+++ b/pmultiqc/modules/common/plots/dia.py
@@ -574,7 +574,21 @@ def draw_loess_rt_irt(sub_section, plot_data):
     )
 
 def calculate_dia_intensity_std(df, sdrf_file_df):
+    """
+    Calculate standard deviation of intensity for DIA data.
 
+    Parameters:
+    -----------
+    df : pd.DataFrame
+        DataFrame with Run, Modified.Sequence, Protein.Group, and log_intensity columns.
+    sdrf_file_df : pd.DataFrame
+        SDRF file DataFrame (can be empty).
+
+    Returns:
+    --------
+    dict or None: Dictionary mapping sample/condition to list of log intensity std values,
+                  or None if calculation cannot be performed.
+    """
     df_sub = df[["Run", "Modified.Sequence", "Protein.Group", "log_intensity"]].copy()
 
     if not sdrf_file_df.empty:
@@ -617,8 +631,9 @@ def calculate_dia_intensity_std(df, sdrf_file_df):
         }
 
         return plot_data
-    else:
-        log.warning("No SDRF available; failed to parse experimental groups; SD Intensity not generated.")
+
+    log.warning("No SDRF available; failed to parse experimental groups; SD Intensity not generated.")
+    return None
 
 def extract_condition_and_replicate(run_name):
 

--- a/pmultiqc/modules/common/plots/general.py
+++ b/pmultiqc/modules/common/plots/general.py
@@ -197,7 +197,9 @@ def draw_exp_design(sub_sections, exp_design):
             "description": "",
             "scale": False,
         }}
-        for k, _ in condition_split(sample_df_slice["MSstats_Condition"].iloc[0]).items():
+        # Use first row of sample_df for condition keys (safer than relying on loop variable)
+        first_condition = sample_df["MSstats_Condition"].iloc[0] if not sample_df.empty else ""
+        for k, _ in condition_split(first_condition).items():
             headers["MSstats_Condition_" + str(k)] = {
                 "title": "MSstats Condition: " + str(k),
                 "description": "",


### PR DESCRIPTION
### **User description**
Bug Fixes:
- Fix division by zero in qual_uniform() when n=0 or sum=0
- Fix missing return in calculate_dia_intensity_std() when no conditions match
- Fix uninitialized variable access for sample_df_slice in draw_exp_design()
- Fix typo: rename recommpute_mass_error to recompute_mass_error

Performance Improvements:
- Optimize cal_delta_mass_dict() to compute value_counts once instead of twice
- Optimize heatmap_charge calculation in msinfo.py to update only current file
- Replace apply(lambda) with vectorized str.rsplit() for path operations

Code Duplication Reduction:
- Extract _prepare_quant_table_data() helper for common table preprocessing
- Extract _merge_condition_data() helper for sample/file merging logic
- Extract _add_condition_headers() helper for header generation

Documentation:
- Add docstrings to qual_uniform() and cal_delta_mass_dict()
- Add docstrings to calculate_dia_intensity_std()

# Pull Request

## Description

Brief description of the changes made in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test addition/update
- [ ] Updates to the dependencies has been done.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix critical bugs: division by zero, missing returns, uninitialized variables

- Optimize performance: eliminate redundant computations and replace lambda with vectorized operations

- Reduce code duplication by extracting three helper functions for table preprocessing

- Add comprehensive docstrings to multiple functions for better code documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bug Fixes"] --> B["qual_uniform, calculate_dia_intensity_std, draw_exp_design, typo fix"]
  C["Performance Optimizations"] --> D["cal_delta_mass_dict, heatmap_charge, vectorized str.rsplit"]
  E["Code Refactoring"] --> F["Extract _prepare_quant_table_data, _merge_condition_data, _add_condition_headers"]
  G["Documentation"] --> H["Add docstrings to multiple functions"]
  B --> I["Improved Code Quality"]
  D --> I
  F --> I
  H --> I
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common_utils.py</strong><dd><code>Fix typo in mass error function naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pmultiqc/modules/common/common_utils.py

<ul><li>Fix typo: rename <code>recommpute_mass_error</code> to <code>recompute_mass_error</code> <br>throughout function and parameter names<br> <li> Update function parameter from <code>recommpute</code> to <code>recompute</code> for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/523/files#diff-21f089c712dda6aeef876569029fa327f35e7d35612e214d79cebe92957710a0">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>msinfo.py</strong><dd><code>Optimize heatmap charge calculation per file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pmultiqc/modules/common/ms/msinfo.py

<ul><li>Fix inefficient heatmap_charge calculation that was iterating over all <br>files in each iteration<br> <li> Optimize to calculate charge ratio only for current file using <code>m_name</code> <br>variable instead of looping through all keys<br> <li> Add clarifying comment explaining the optimization</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/523/files#diff-9dfee07e04394cc8218b8eb6db2b1995659acd1ac24a37857e927bb139803904">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dia.py</strong><dd><code>Add docstring and fix missing return statement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pmultiqc/modules/common/plots/dia.py

<ul><li>Add comprehensive docstring to <code>calculate_dia_intensity_std()</code> with <br>parameters and return value documentation<br> <li> Fix missing return statement: add explicit <code>return None</code> when SDRF is <br>empty instead of implicit None<br> <li> Improve code clarity by removing unnecessary <code>else</code> block and using <br>early return pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/523/files#diff-03ed6d774a65647bd6dd990ad8aa9137b4fbdfed27056f0f8c89ab2b84f8f5a7">+18/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>general.py</strong><dd><code>Fix uninitialized variable in condition split</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pmultiqc/modules/common/plots/general.py

<ul><li>Fix uninitialized variable access: replace unsafe <code>sample_df_slice</code> <br>reference with <code>sample_df</code> which is guaranteed to exist<br> <li> Add safety check to handle empty DataFrames when accessing first row<br> <li> Add clarifying comment explaining the fix</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/523/files#diff-2961927ecf11dc8032d29ac2ecb3ed59305eae874cfc590f7270c237167c6d4f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stats.py</strong><dd><code>Fix division by zero and optimize mass delta calculation</code>&nbsp; </dd></summary>
<hr>

pmultiqc/modules/common/stats.py

<ul><li>Fix division by zero in <code>qual_uniform()</code> by adding checks for n=0 and <br>sum=0 cases, returning 0.0 when either occurs<br> <li> Add comprehensive docstring with parameters and return value <br>documentation<br> <li> Optimize <code>cal_delta_mass_dict()</code> to compute <code>value_counts()</code> once instead <br>of twice by deriving frequency from counts<br> <li> Add <code>num_bins</code> parameter with default value 1000 for flexibility<br> <li> Add detailed docstring with parameters and return value documentation<br> <li> Replace explicit loops with dictionary comprehensions for cleaner code</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/523/files#diff-d1eac777c2583033d5077302913bbee7ef2f4bb739371354c13262b68a485575">+47/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dia_utils.py</strong><dd><code>Extract helpers and optimize quantification table creation</code></dd></summary>
<hr>

pmultiqc/modules/common/dia_utils.py

<ul><li>Extract <code>_prepare_quant_table_data()</code> helper to consolidate common <br>preprocessing logic for quantification tables<br> <li> Extract <code>_merge_condition_data()</code> helper to handle sample/file merging <br>and vectorized path splitting using <code>str.rsplit()</code> instead of <br><code>apply(lambda)</code><br> <li> Extract <code>_add_condition_headers()</code> helper to centralize header <br>generation for conditions<br> <li> Refactor <code>create_peptides_table()</code> and <code>create_protein_table()</code> to use new <br>helpers, reducing code duplication by ~50 lines<br> <li> Replace <code>dict()</code> with <code>{}</code> for consistency and replace explicit loops with <br>dictionary comprehensions<br> <li> Add docstrings to <code>create_peptides_table()</code> and <code>create_protein_table()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/523/files#diff-8a5636b29881cb144c74a8617d3da6e89da2afdbd338b291bc8e3419836265ef">+69/-67</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

