### PR TITLE
fix

### DIFF
--- a/pmultiqc/modules/common/common_utils.py
+++ b/pmultiqc/modules/common/common_utils.py
@@ -407,7 +407,7 @@ def recompute_mass_error(evidence_df):
     ]
 
     if not all(col in evidence_df.columns for col in required_cols):
-        log.info("Evidence is missing one or more required columns in recommpute_mass_error.")
+        log.info("Evidence is missing one or more required columns in recompute_mass_error.")
         return None
 
     df = evidence_df[required_cols].copy()

--- a/pmultiqc/modules/maxquant/maxquant_utils.py
+++ b/pmultiqc/modules/maxquant/maxquant_utils.py
@@ -19,7 +19,7 @@ from pmultiqc.modules.common.stats import (
 from pmultiqc.modules.common.common_utils import (
     mods_statistics,
     evidence_rt_count,
-    recommpute_mass_error,
+    recompute_mass_error,
     evidence_calibrated_mass_error
 )
 
@@ -910,7 +910,7 @@ def evidence_uncalibrated_mass_error(evidence_data):
     if "potential contaminant" in evidence_data.columns:
         evidence_data = evidence_data[evidence_data["potential contaminant"] != "+"].copy()
 
-    evd_df = recommpute_mass_error(evidence_data)
+    evd_df = recompute_mass_error(evidence_data)
 
     if evd_df is None:
         if any(


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix typo in function name `recommpute_mass_error` to `recompute_mass_error`

- Update all references to use corrected function name

- Fix typo in log message from `recommpute_mass_error` to `recompute_mass_error`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Typo: recommpute_mass_error"] -- "Fix function name" --> B["Corrected: recompute_mass_error"]
  C["Update imports"] -- "Use correct name" --> B
  D["Update function calls"] -- "Use correct name" --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common_utils.py</strong><dd><code>Fix typo in log message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pmultiqc/modules/common/common_utils.py

<ul><li>Fix typo in log message from <code>recommpute_mass_error</code> to <br><code>recompute_mass_error</code><br> <li> Corrects the function name reference in error logging</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/525/files#diff-21f089c712dda6aeef876569029fa327f35e7d35612e214d79cebe92957710a0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>maxquant_utils.py</strong><dd><code>Fix typo in function name and import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pmultiqc/modules/maxquant/maxquant_utils.py

<ul><li>Fix import statement to use correct function name <code>recompute_mass_error</code><br> <li> Update function call from <code>recommpute_mass_error</code> to <br><code>recompute_mass_error</code> in <code>evidence_uncalibrated_mass_error</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/pmultiqc/pull/525/files#diff-1e0b09780abe9f59cf2285cdf491e004ddcdf4d4542f694b1b1e4260b9b9e031">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

