### PR TITLE
Refactor pmultiqc service to support FragPipe

### DIFF
--- a/pmultiqc_service/templates/index.html
+++ b/pmultiqc_service/templates/index.html
@@ -974,26 +974,53 @@
 
                 <!-- COMPLETE Example -->
                 <div style="
-                    border: 1px solid #e9ecef; 
-                    border-radius: 8px; 
-                    padding: 15px; 
+                    border: 1px solid #e9ecef;
+                    border-radius: 8px;
+                    padding: 15px;
                     background: #f8f9fa;
                 ">
                     <div style="display: flex; justify-content: space-between; align-items: center;">
                         <div>
                             <h4 style="margin: 0 0 5px 0; color: #333;">PXD051187 - COMPLETE Submission</h4>
                             <p style="margin: 0; color: #666; font-size: 14px;">
-                                A COMPLETE submission containing mzIdentML files with associated peak lists (MGF/mzML). 
+                                A COMPLETE submission containing mzIdentML files with associated peak lists (MGF/mzML).
                                 This dataset demonstrates the processing of compressed mzIdentML files and their corresponding peak list files.
                             </p>
                         </div>
                         <button onclick="selectExample('PXD051187')" style="
-                            background: linear-gradient(45deg, #fd7e14, #e55a00); 
-                            color: white; 
-                            border: none; 
-                            padding: 8px 16px; 
-                            border-radius: 6px; 
-                            cursor: pointer; 
+                            background: linear-gradient(45deg, #fd7e14, #e55a00);
+                            color: white;
+                            border: none;
+                            padding: 8px 16px;
+                            border-radius: 6px;
+                            cursor: pointer;
+                            font-size: 12px;
+                        ">Use This Example</button>
+                    </div>
+                </div>
+
+                <!-- FragPipe Example -->
+                <div style="
+                    border: 1px solid #e9ecef;
+                    border-radius: 8px;
+                    padding: 15px;
+                    background: #f8f9fa;
+                ">
+                    <div style="display: flex; justify-content: space-between; align-items: center;">
+                        <div>
+                            <h4 style="margin: 0 0 5px 0; color: #333;">PXD066146 - FragPipe Analysis</h4>
+                            <p style="margin: 0; color: #666; font-size: 14px;">
+                                A FragPipe analysis dataset with psm.tsv and ion.tsv files.
+                                This dataset demonstrates FragPipe/MSFragger output format and quality metrics visualization.
+                            </p>
+                        </div>
+                        <button onclick="selectExample('PXD066146')" style="
+                            background: linear-gradient(45deg, #17a2b8, #138496);
+                            color: white;
+                            border: none;
+                            padding: 8px 16px;
+                            border-radius: 6px;
+                            cursor: pointer;
                             font-size: 12px;
                         ">Use This Example</button>
                     </div>


### PR DESCRIPTION
Add FragPipe as an additional supported dataset format that can be loaded from PRIDE and processed by the pmultiqc service.

Changes:
- Add FragPipe file detection (psm.tsv, ion.tsv) in detect_input_type()
- Add FragPipe files to filter_search_files() for PRIDE dataset filtering
- Add 'fragpipe' to allowed_input_types and --fragpipe-plugin handling
- Add PXD066146 as a FragPipe example in the PRIDE examples modal

# Pull Request

## Description

Brief description of the changes made in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test addition/update
- [ ] Updates to the dependencies has been done. 

