### PR TITLE
Fix table rendering in docs webpage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -250,6 +250,7 @@ You can find example reports on the [docs page](https://bigbio.github.io/pmultiq
 | FragPipe | FragPipe results | [FragPipe Example](https://pmultiqc.quantms.org/PXD062399/multiqc_report.html) ([disable_hoverinfo](https://pmultiqc.quantms.org/PXD062399_disable_hoverinfo/multiqc_report.html)) | [PXD062399.zip](https://ftp.pride.ebi.ac.uk/pub/databases/pride/resources/proteomes/pmultiqc/example-projects/PXD062399.zip) |
 
 ### 🔍 Large-Scale Dataset Reports
+
 | Example Type | Description | Link | Dataset Download |
 |---|---|---|---|
 | Big quantms DIA | Data-independent acquisition | [Big quantms DIA - 165 samples](https://pmultiqc.quantms.org/PXD062383/multiqc_report.html) ([disable_hoverinfo](https://pmultiqc.quantms.org/PXD062383_disable_hoverinfo/multiqc_report.html)) | [PXD062383.zip](https://ftp.pride.ebi.ac.uk/pub/databases/pride/resources/proteomes/pmultiqc/example-projects/PXD062383.zip) |


### PR DESCRIPTION
The Large-Scale Dataset Reports table was not rendering properly because it was missing a blank line between the heading and the table header. Markdown requires a blank line before tables to recognize them.

# Pull Request

## Description

Brief description of the changes made in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test addition/update
- [ ] Updates to the dependencies has been done. 

