### PR TITLE
Fix syntax error in dataframe column selection

### DIFF
--- a/pmultiqc/modules/common/dia_utils.py
+++ b/pmultiqc/modules/common/dia_utils.py
@@ -226,9 +226,13 @@ def _process_run_data(df, ms_with_psm, quantms_modified, sdrf_file_df):
 
     log.info("Processing DIA mod_plot_dict.")
 
-    report_data = df[
-        ["Run", "Modified.Sequence", "Modifications", "Protein.Group", "Proteotypic"]
-    ].copy()
+    required_cols = ["Run", "Modified.Sequence", "Modifications", "Protein.Group"]
+    report_data = df[required_cols].copy()
+    if "Proteotypic" in df.columns:
+        report_data["Proteotypic"] = df["Proteotypic"]
+    else:
+        log.warning("Missing Proteotypic column; treating all peptides as proteotypic.")
+        report_data["Proteotypic"] = 1
 
     mod_plot_by_run = dict()
     modified_cats = list()


### PR DESCRIPTION
Make the code robust when the Proteotypic column is not present in the DataFrame by conditionally adding it. If missing, log a warning and default all peptides to proteotypic (value 1).

# Pull Request

## Description

Brief description of the changes made in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test addition/update
- [ ] Updates to the dependencies has been done. 

