### PR TITLE
feat(qpx): derive experimental design from run/sample parquet

### DIFF
--- a/pmultiqc/main.py
+++ b/pmultiqc/main.py
@@ -200,5 +200,10 @@ def pmultiqc_plugin_execution_start():
             config.sp,
             {"pmultiqc/qpx_run": {"fn": "*.run.parquet", "num_lines": 0}},
         )
+    if "pmultiqc/qpx_sample" not in config.sp:
+        config.update_dict(
+            config.sp,
+            {"pmultiqc/qpx_sample": {"fn": "*.sample.parquet", "num_lines": 0}},
+        )
 
     config.update({"log_filesize_limit": 200 * pow(1024, 3), "thousandsSep_format": ""})

--- a/pmultiqc/modules/common/dia_utils.py
+++ b/pmultiqc/modules/common/dia_utils.py
@@ -591,6 +591,19 @@ def draw_protein_table(sub_sections, table_data, headers, report_type):
             * Peptides_Number: The number of peptides for each protein.
             * Average Intensity: Average intensity of each protein(0 or NA ignored).
             """
+    elif report_type == "qpx":
+        description_text = """
+            This plot shows the quantification information of proteins in the final result (quantms.io pg.parquet).
+            """
+        helptext_text = """
+            The quantification information of proteins is obtained from the `intensity` column of pg.parquet.
+            Proteins are sorted by average intensity, and the most abundant ones are shown.
+
+            * Peptides_Number: The number of distinct peptide sequences for each protein.
+            * Average Intensity: log10 of the average protein group intensity across runs (0 or NA ignored).
+            * Global Q-value: The best (lowest) global q-value reported for the protein group.
+            * Protein intensity in each condition: log10 average intensity within that condition.
+            """
     else:
         description_text = ""
         helptext_text = ""

--- a/pmultiqc/modules/common/plots/dia.py
+++ b/pmultiqc/modules/common/plots/dia.py
@@ -4,7 +4,7 @@ import pandas as pd
 from multiqc.plots import heatmap, box, bargraph, linegraph
 
 from pmultiqc.modules.common.plots.general import (
-    box_axis_range,
+    trim_box_outliers,
     plot_html_check,
     plot_data_check
 )
@@ -121,11 +121,9 @@ def draw_dia_intensity_dis(sub_section, df, sdrf_file_df):
         "save_data_file": False,
     }
 
-    # log2 intensities sit far from zero and have long tails, so an unset axis both
-    # wastes the left half and lets a few outliers shrink every box.
-    x_range = box_axis_range(box_data)
-    if x_range:
-        draw_config["xmin"], draw_config["xmax"] = x_range
+    # The box plot auto-scales its value axis, so trim the long log2-intensity tails
+    # rather than trying to set a range that MultiQC discards.
+    box_data, _dropped = trim_box_outliers(box_data)
 
     box_html = box.plot(list_of_data_by_sample=box_data, pconfig=draw_config)
 

--- a/pmultiqc/modules/common/plots/dia.py
+++ b/pmultiqc/modules/common/plots/dia.py
@@ -4,6 +4,7 @@ import pandas as pd
 from multiqc.plots import heatmap, box, bargraph, linegraph
 
 from pmultiqc.modules.common.plots.general import (
+    box_axis_range,
     plot_html_check,
     plot_data_check
 )
@@ -119,6 +120,12 @@ def draw_dia_intensity_dis(sub_section, df, sdrf_file_df):
         "sort_samples": False,
         "save_data_file": False,
     }
+
+    # log2 intensities sit far from zero and have long tails, so an unset axis both
+    # wastes the left half and lets a few outliers shrink every box.
+    x_range = box_axis_range(box_data)
+    if x_range:
+        draw_config["xmin"], draw_config["xmax"] = x_range
 
     box_html = box.plot(list_of_data_by_sample=box_data, pconfig=draw_config)
 

--- a/pmultiqc/modules/common/plots/dia.py
+++ b/pmultiqc/modules/common/plots/dia.py
@@ -4,7 +4,7 @@ import pandas as pd
 from multiqc.plots import heatmap, box, bargraph, linegraph
 
 from pmultiqc.modules.common.plots.general import (
-    trim_box_outliers,
+    summarise_box_data,
     plot_html_check,
     plot_data_check
 )
@@ -121,9 +121,9 @@ def draw_dia_intensity_dis(sub_section, df, sdrf_file_df):
         "save_data_file": False,
     }
 
-    # The box plot auto-scales its value axis, so trim the long log2-intensity tails
-    # rather than trying to set a range that MultiQC discards.
-    box_data, _dropped = trim_box_outliers(box_data)
+    # Summarise to box statistics so a large report stays interactive rather than
+    # falling back to a flat image that does not fill the panel.
+    box_data = summarise_box_data(box_data)
 
     box_html = box.plot(list_of_data_by_sample=box_data, pconfig=draw_config)
 

--- a/pmultiqc/modules/common/plots/general.py
+++ b/pmultiqc/modules/common/plots/general.py
@@ -142,6 +142,15 @@ def draw_exp_design(sub_sections, exp_design):
     # Currently this only supports the OpenMS two-table format (default in quantms pipeline)
     sample_df, file_df = read_openms_design(exp_design)
 
+    return draw_exp_design_tables(sub_sections, sample_df, file_df)
+
+
+def draw_exp_design_tables(sub_sections, sample_df, file_df):
+    """Render the Experimental Design table from already-parsed design tables.
+
+    Split out of draw_exp_design so callers that derive the design from somewhere
+    other than an OpenMS design file (e.g. quantms.io parquet) can reuse it.
+    """
     exp_design_runs = file_df["Run"].unique().tolist()
 
     is_bruker = False

--- a/pmultiqc/modules/common/plots/general.py
+++ b/pmultiqc/modules/common/plots/general.py
@@ -424,69 +424,63 @@ def draw_search_engine_scores(sub_section, plot_data, plot_type):
     )
 
 
-def trim_box_outliers(plot_data, lower_percentile=1.0, upper_percentile=99.0):
-    """Drop values outside a percentile window so the auto-scaled axis stays readable.
+def summarise_box_data(plot_data, whisker_iqr=1.5):
+    """Replace raw per-sample value lists with the box statistics MultiQC can plot.
 
-    MultiQC's box plot ignores xmin/xmax and ymin/ymax: it renders horizontally and
-    rebuilds layout.xaxis from the y settings, discarding any range, so the value axis
-    is always auto-scaled to the data. The only way to control it is to control what is
-    plotted.
+    MultiQC switches a plot to a flat static image once it exceeds FLAT_THRESHOLD data
+    points, and a flat image does not stretch to the panel width -- the peptide
+    intensity box carried ~450,000 values and rendered at roughly half width because of
+    it. Its box plot also accepts pre-computed statistics: when a sample maps to a dict
+    rather than a list, it is used directly.
 
-    log2 intensity distributions have long tails -- for peptide intensity the
-    interquartile range is under 15% of the min-max span -- so a handful of extreme
-    points flatten every box. Trimming the outer 1% at each end keeps the axis tight
-    while leaving the box, median and whiskers essentially unchanged.
+    Summarising to {min, q1, median, q3, max, mean} keeps the plot interactive (a few
+    dozen numbers instead of hundreds of thousands), so it fills the panel, and removes
+    any need to discard data for display. Fences follow the usual Tukey convention, so
+    the whiskers show the data range excluding outliers rather than the absolute
+    extremes -- which is what a box plot conventionally depicts anyway.
 
-    Returns a new structure of the same shape (list of dicts, or a single dict). The
-    number of dropped points is returned alongside so callers can disclose it.
+    Returns a structure of the same shape (list of dicts, or a single dict).
     """
     if not plot_data:
-        return plot_data, 0
+        return plot_data
 
     was_list = isinstance(plot_data, list)
     datasets = plot_data if was_list else [plot_data]
 
-    values = []
+    summarised = []
     for dataset in datasets:
         if not isinstance(dataset, dict):
+            summarised.append(dataset)
             continue
-        for series in dataset.values():
-            if series is None:
-                continue
-            try:
-                values.extend(v for v in series if v is not None and np.isfinite(v))
-            except TypeError:
-                continue
 
-    if len(values) < 100:
-        # Too few points for percentile trimming to be meaningful.
-        return plot_data, 0
-
-    array = np.asarray(values, dtype=float)
-    low = float(np.percentile(array, lower_percentile))
-    high = float(np.percentile(array, upper_percentile))
-    if not np.isfinite(low) or not np.isfinite(high) or high <= low:
-        return plot_data, 0
-
-    dropped = 0
-    trimmed_datasets = []
-    for dataset in datasets:
-        if not isinstance(dataset, dict):
-            trimmed_datasets.append(dataset)
-            continue
-        trimmed = {}
+        out = {}
         for sample, series in dataset.items():
-            if series is None:
-                trimmed[sample] = series
+            if isinstance(series, dict):
+                out[sample] = series  # already statistics
                 continue
             try:
-                kept = [v for v in series if v is not None and low <= v <= high]
-            except TypeError:
-                trimmed[sample] = series
+                array = np.asarray([v for v in series if v is not None], dtype=float)
+            except (TypeError, ValueError):
+                out[sample] = series
                 continue
-            dropped += len(series) - len(kept)
-            # Never empty a sample entirely -- that would drop it from the plot.
-            trimmed[sample] = kept if kept else list(series)
-        trimmed_datasets.append(trimmed)
 
-    return (trimmed_datasets if was_list else trimmed_datasets[0]), dropped
+            array = array[np.isfinite(array)]
+            if array.size == 0:
+                continue
+
+            q1, median, q3 = (float(v) for v in np.percentile(array, [25, 50, 75]))
+            iqr = q3 - q1
+            low_fence = float(array[array >= q1 - whisker_iqr * iqr].min()) if iqr > 0 else float(array.min())
+            high_fence = float(array[array <= q3 + whisker_iqr * iqr].max()) if iqr > 0 else float(array.max())
+
+            out[sample] = {
+                "min": low_fence,
+                "q1": q1,
+                "median": median,
+                "q3": q3,
+                "max": high_fence,
+                "mean": float(array.mean()),
+            }
+        summarised.append(out)
+
+    return summarised if was_list else summarised[0]

--- a/pmultiqc/modules/common/plots/general.py
+++ b/pmultiqc/modules/common/plots/general.py
@@ -424,26 +424,27 @@ def draw_search_engine_scores(sub_section, plot_data, plot_type):
     )
 
 
-def box_axis_range(plot_data, lower_percentile=1.0, upper_percentile=99.0, margin_fraction=0.05):
-    """Axis bounds fitted to the bulk of box-plot data, or None if undeterminable.
+def trim_box_outliers(plot_data, lower_percentile=1.0, upper_percentile=99.0):
+    """Drop values outside a percentile window so the auto-scaled axis stays readable.
 
-    Two problems with leaving the axis to default. log2 intensities sit far from zero,
-    so an axis anchored at 0 wastes most of the width. And fitting to absolute min/max
-    is barely better when the tails are long: a handful of extreme points stretch the
-    axis until every box collapses -- for peptide intensity the interquartile range is
-    only ~15% of the min-max span.
+    MultiQC's box plot ignores xmin/xmax and ymin/ymax: it renders horizontally and
+    rebuilds layout.xaxis from the y settings, discarding any range, so the value axis
+    is always auto-scaled to the data. The only way to control it is to control what is
+    plotted.
 
-    So the range is taken from percentiles (1st-99th by default), which keeps the boxes
-    and whiskers legible. Points outside that range are still drawn by the plotting
-    library but may fall beyond the visible axis; widen the percentiles if every outlier
-    must be on screen. The result never extends past the real data.
+    log2 intensity distributions have long tails -- for peptide intensity the
+    interquartile range is under 15% of the min-max span -- so a handful of extreme
+    points flatten every box. Trimming the outer 1% at each end keeps the axis tight
+    while leaving the box, median and whiskers essentially unchanged.
 
-    Returns ``(xmin, xmax)``.
+    Returns a new structure of the same shape (list of dicts, or a single dict). The
+    number of dropped points is returned alongside so callers can disclose it.
     """
     if not plot_data:
-        return None
+        return plot_data, 0
 
-    datasets = plot_data if isinstance(plot_data, list) else [plot_data]
+    was_list = isinstance(plot_data, list)
+    datasets = plot_data if was_list else [plot_data]
 
     values = []
     for dataset in datasets:
@@ -457,23 +458,35 @@ def box_axis_range(plot_data, lower_percentile=1.0, upper_percentile=99.0, margi
             except TypeError:
                 continue
 
-    if not values:
-        return None
+    if len(values) < 100:
+        # Too few points for percentile trimming to be meaningful.
+        return plot_data, 0
 
     array = np.asarray(values, dtype=float)
-    array = array[np.isfinite(array)]
-    if array.size == 0:
-        return None
-
     low = float(np.percentile(array, lower_percentile))
     high = float(np.percentile(array, upper_percentile))
-
-    # Degenerate percentiles (e.g. a near-constant series) fall back to the full range.
     if not np.isfinite(low) or not np.isfinite(high) or high <= low:
-        low, high = float(array.min()), float(array.max())
-    if high <= low:
-        return None
+        return plot_data, 0
 
-    margin = (high - low) * margin_fraction
-    # Never claim range the data does not occupy.
-    return max(low - margin, float(array.min())), min(high + margin, float(array.max()))
+    dropped = 0
+    trimmed_datasets = []
+    for dataset in datasets:
+        if not isinstance(dataset, dict):
+            trimmed_datasets.append(dataset)
+            continue
+        trimmed = {}
+        for sample, series in dataset.items():
+            if series is None:
+                trimmed[sample] = series
+                continue
+            try:
+                kept = [v for v in series if v is not None and low <= v <= high]
+            except TypeError:
+                trimmed[sample] = series
+                continue
+            dropped += len(series) - len(kept)
+            # Never empty a sample entirely -- that would drop it from the plot.
+            trimmed[sample] = kept if kept else list(series)
+        trimmed_datasets.append(trimmed)
+
+    return (trimmed_datasets if was_list else trimmed_datasets[0]), dropped

--- a/pmultiqc/modules/common/plots/general.py
+++ b/pmultiqc/modules/common/plots/general.py
@@ -422,3 +422,38 @@ def draw_search_engine_scores(sub_section, plot_data, plot_type):
         description="",
         helptext=plot_config["helptext"],
     )
+
+
+def box_axis_range(plot_data, margin_fraction=0.05):
+    """Axis bounds fitted to box-plot data, or None when it cannot be determined.
+
+    Box plots of log2 intensity sit far from zero, so an axis left to default from 0
+    compresses every box into a fraction of the plot. Returns ``(xmin, xmax)`` padded
+    by a small margin so the whiskers are not flush against the edges.
+    """
+    if not plot_data:
+        return None
+
+    datasets = plot_data if isinstance(plot_data, list) else [plot_data]
+
+    values = []
+    for dataset in datasets:
+        if not isinstance(dataset, dict):
+            continue
+        for series in dataset.values():
+            if series is None:
+                continue
+            try:
+                values.extend(v for v in series if v is not None and np.isfinite(v))
+            except TypeError:
+                continue
+
+    if not values:
+        return None
+
+    low, high = float(min(values)), float(max(values))
+    if not np.isfinite(low) or not np.isfinite(high) or high <= low:
+        return None
+
+    margin = (high - low) * margin_fraction
+    return low - margin, high + margin

--- a/pmultiqc/modules/common/plots/general.py
+++ b/pmultiqc/modules/common/plots/general.py
@@ -424,7 +424,7 @@ def draw_search_engine_scores(sub_section, plot_data, plot_type):
     )
 
 
-def summarise_box_data(plot_data, whisker_iqr=1.5):
+def summarise_box_data(plot_data, whisker_iqr=1.5, max_points=None):
     """Replace raw per-sample value lists with the box statistics MultiQC can plot.
 
     MultiQC switches a plot to a flat static image once it exceeds FLAT_THRESHOLD data
@@ -439,6 +439,10 @@ def summarise_box_data(plot_data, whisker_iqr=1.5):
     the whiskers show the data range excluding outliers rather than the absolute
     extremes -- which is what a box plot conventionally depicts anyway.
 
+    Only applied when the raw point count would actually trip the threshold: below it
+    the raw values are returned untouched, so smaller reports keep showing individual
+    outlier points as before.
+
     Returns a structure of the same shape (list of dicts, or a single dict).
     """
     if not plot_data:
@@ -446,6 +450,23 @@ def summarise_box_data(plot_data, whisker_iqr=1.5):
 
     was_list = isinstance(plot_data, list)
     datasets = plot_data if was_list else [plot_data]
+
+    # Only summarise when the raw data would otherwise trip the flat-image fallback.
+    # Below that, keep the raw values so the plot still shows individual outlier points.
+    limit = FLAT_THRESHOLD if max_points is None else max_points
+    total = 0
+    for dataset in datasets:
+        if not isinstance(dataset, dict):
+            continue
+        for series in dataset.values():
+            if isinstance(series, dict) or series is None:
+                continue
+            try:
+                total += len(series)
+            except TypeError:
+                continue
+    if total < limit:
+        return plot_data
 
     summarised = []
     for dataset in datasets:

--- a/pmultiqc/modules/common/plots/general.py
+++ b/pmultiqc/modules/common/plots/general.py
@@ -424,12 +424,21 @@ def draw_search_engine_scores(sub_section, plot_data, plot_type):
     )
 
 
-def box_axis_range(plot_data, margin_fraction=0.05):
-    """Axis bounds fitted to box-plot data, or None when it cannot be determined.
+def box_axis_range(plot_data, lower_percentile=1.0, upper_percentile=99.0, margin_fraction=0.05):
+    """Axis bounds fitted to the bulk of box-plot data, or None if undeterminable.
 
-    Box plots of log2 intensity sit far from zero, so an axis left to default from 0
-    compresses every box into a fraction of the plot. Returns ``(xmin, xmax)`` padded
-    by a small margin so the whiskers are not flush against the edges.
+    Two problems with leaving the axis to default. log2 intensities sit far from zero,
+    so an axis anchored at 0 wastes most of the width. And fitting to absolute min/max
+    is barely better when the tails are long: a handful of extreme points stretch the
+    axis until every box collapses -- for peptide intensity the interquartile range is
+    only ~15% of the min-max span.
+
+    So the range is taken from percentiles (1st-99th by default), which keeps the boxes
+    and whiskers legible. Points outside that range are still drawn by the plotting
+    library but may fall beyond the visible axis; widen the percentiles if every outlier
+    must be on screen. The result never extends past the real data.
+
+    Returns ``(xmin, xmax)``.
     """
     if not plot_data:
         return None
@@ -451,9 +460,20 @@ def box_axis_range(plot_data, margin_fraction=0.05):
     if not values:
         return None
 
-    low, high = float(min(values)), float(max(values))
+    array = np.asarray(values, dtype=float)
+    array = array[np.isfinite(array)]
+    if array.size == 0:
+        return None
+
+    low = float(np.percentile(array, lower_percentile))
+    high = float(np.percentile(array, upper_percentile))
+
+    # Degenerate percentiles (e.g. a near-constant series) fall back to the full range.
     if not np.isfinite(low) or not np.isfinite(high) or high <= low:
+        low, high = float(array.min()), float(array.max())
+    if high <= low:
         return None
 
     margin = (high - low) * margin_fraction
-    return low - margin, high + margin
+    # Never claim range the data does not occupy.
+    return max(low - margin, float(array.min())), min(high + margin, float(array.max()))

--- a/pmultiqc/modules/common/plots/id.py
+++ b/pmultiqc/modules/common/plots/id.py
@@ -8,7 +8,7 @@ from multiqc.plots.table_object import InputRow
 from pmultiqc.modules.core.section_groups import add_sub_section
 from pmultiqc.modules.common.common_utils import condition_split
 from pmultiqc.modules.common.plots.general import (
-    box_axis_range,
+    trim_box_outliers,
     plot_html_check,
     plot_data_check
 )
@@ -1160,11 +1160,9 @@ def draw_peptide_intensity(sub_section, plot_data):
         "save_data_file": False,
     }
 
-    # log2 intensities sit far from zero (typically ~20-35), so an axis anchored at 0
-    # squeezes every box into a fraction of the plot width. Fit the axis to the data.
-    x_range = box_axis_range(plot_data)
-    if x_range:
-        draw_config["xmin"], draw_config["xmax"] = x_range
+    # MultiQC's box plot auto-scales its value axis and ignores xmin/xmax, so the only
+    # way to keep the boxes readable is to trim the long log2-intensity tails.
+    plot_data, dropped = trim_box_outliers(plot_data)
 
     if len(plot_data) > 1 and plot_data[1]:
         draw_config["data_labels"] = ["by Run", "by Sample"]
@@ -1186,7 +1184,11 @@ def draw_peptide_intensity(sub_section, plot_data):
         sub_section=sub_section,
         plot=box_html,
         order=5,
-        description="Peptide intensity per Run.",
+        description=(
+            "Peptide intensity per Run."
+            + (f" The most extreme {dropped:,} values are omitted so the boxes stay legible."
+               if dropped else "")
+        ),
         helptext="""
             quantms: Calculate the average of peptide_abundance_study_variable[1-n] values for each peptide from the
             peptide table in the 'mzTab', and then apply a log2 transformation.

--- a/pmultiqc/modules/common/plots/id.py
+++ b/pmultiqc/modules/common/plots/id.py
@@ -75,6 +75,15 @@ def draw_potential_contaminants(sub_section, contaminant_percent, report_type):
 
             Note that this plot is based on experimental groups, and therefore may not correspond 1:1 to Raw files.
             """
+    elif report_type == "qpx":
+        description_text = "Potential contaminants per run from pg.parquet."
+        help_text = """
+            Share of the summed protein-group intensity in each run that comes from
+            contaminant protein groups. A group counts as a contaminant when
+            pg.parquet marks it with the `contaminant` flag, or -- when that flag marks
+            nothing, as some converters leave it unset -- when its accession contains
+            the configured contaminant affix (`--contaminant-affix`, default CONT).
+            """
     elif report_type == "fragpipe":
         description_text = "Potential contaminants per group from psm.tsv."
         help_text = """

--- a/pmultiqc/modules/common/plots/id.py
+++ b/pmultiqc/modules/common/plots/id.py
@@ -8,7 +8,7 @@ from multiqc.plots.table_object import InputRow
 from pmultiqc.modules.core.section_groups import add_sub_section
 from pmultiqc.modules.common.common_utils import condition_split
 from pmultiqc.modules.common.plots.general import (
-    trim_box_outliers,
+    summarise_box_data,
     plot_html_check,
     plot_data_check
 )
@@ -1160,9 +1160,9 @@ def draw_peptide_intensity(sub_section, plot_data):
         "save_data_file": False,
     }
 
-    # MultiQC's box plot auto-scales its value axis and ignores xmin/xmax, so the only
-    # way to keep the boxes readable is to trim the long log2-intensity tails.
-    plot_data, dropped = trim_box_outliers(plot_data)
+    # Summarise to box statistics: several hundred thousand raw values would push the
+    # plot over the flat-image threshold, and a flat plot does not fill the panel.
+    plot_data = summarise_box_data(plot_data)
 
     if len(plot_data) > 1 and plot_data[1]:
         draw_config["data_labels"] = ["by Run", "by Sample"]
@@ -1184,11 +1184,7 @@ def draw_peptide_intensity(sub_section, plot_data):
         sub_section=sub_section,
         plot=box_html,
         order=5,
-        description=(
-            "Peptide intensity per Run."
-            + (f" The most extreme {dropped:,} values are omitted so the boxes stay legible."
-               if dropped else "")
-        ),
+        description="Peptide intensity per Run.",
         helptext="""
             quantms: Calculate the average of peptide_abundance_study_variable[1-n] values for each peptide from the
             peptide table in the 'mzTab', and then apply a log2 transformation.

--- a/pmultiqc/modules/common/plots/id.py
+++ b/pmultiqc/modules/common/plots/id.py
@@ -8,6 +8,7 @@ from multiqc.plots.table_object import InputRow
 from pmultiqc.modules.core.section_groups import add_sub_section
 from pmultiqc.modules.common.common_utils import condition_split
 from pmultiqc.modules.common.plots.general import (
+    box_axis_range,
     plot_html_check,
     plot_data_check
 )
@@ -1158,6 +1159,12 @@ def draw_peptide_intensity(sub_section, plot_data):
         "sort_samples": False,
         "save_data_file": False,
     }
+
+    # log2 intensities sit far from zero (typically ~20-35), so an axis anchored at 0
+    # squeezes every box into a fraction of the plot width. Fit the axis to the data.
+    x_range = box_axis_range(plot_data)
+    if x_range:
+        draw_config["xmin"], draw_config["xmax"] = x_range
 
     if len(plot_data) > 1 and plot_data[1]:
         draw_config["data_labels"] = ["by Run", "by Sample"]

--- a/pmultiqc/modules/fragpipe/fragpipe.py
+++ b/pmultiqc/modules/fragpipe/fragpipe.py
@@ -56,6 +56,7 @@ from pmultiqc.modules.common.common_utils import (
 from pmultiqc.modules.common.plots.general import (
     plot_html_check,
     plot_data_check,
+    summarise_box_data,
     stat_pep_intensity,
     search_engine_score_bins,
     draw_search_engine_scores,
@@ -1033,6 +1034,10 @@ class FragPipeModule(BasePMultiqcModule):
             "save_data_file": False,
         }
 
+        # Summarise to box statistics so a large report stays interactive rather than
+        # falling back to a flat image that does not fill the panel.
+        distribution = summarise_box_data(distribution)
+
         box_html = box.plot(list_of_data_by_sample=distribution, pconfig=draw_config)
 
         box_html = plot_data_check(
@@ -1229,6 +1234,8 @@ class FragPipeModule(BasePMultiqcModule):
             "xlab": "log2(Intensity)",
             "save_data_file": False,
         }
+
+        distribution_box = summarise_box_data(distribution_box)
 
         box_html = box.plot(list_of_data_by_sample=distribution_box, pconfig=draw_config)
 

--- a/pmultiqc/modules/maxquant/maxquant_plots.py
+++ b/pmultiqc/modules/maxquant/maxquant_plots.py
@@ -7,7 +7,8 @@ from multiqc.types import SampleGroup, SampleName
 
 from pmultiqc.modules.common.plots.general import (
     plot_html_check,
-    plot_data_check
+    plot_data_check,
+    summarise_box_data
 )
 from pmultiqc.modules.core.section_groups import add_sub_section
 
@@ -242,6 +243,10 @@ def draw_intensity_box(sub_section, distribution_box, fig_type):
     else:
         boxplot_label = ["Sample"]
         distribution_box = distribution_box[:1]
+
+    # Summarise to box statistics: past FLAT_THRESHOLD data points MultiQC falls back to
+    # a flat static image, which renders at a fixed size instead of filling the panel.
+    distribution_box = summarise_box_data(distribution_box)
 
     # 'intensity'
     if fig_type == "intensity":

--- a/pmultiqc/modules/qpx/qpx.py
+++ b/pmultiqc/modules/qpx/qpx.py
@@ -38,15 +38,15 @@ from pmultiqc.modules.common.logging import get_logger
 from pmultiqc.modules.qpx.qpx_design import build_design_from_parquet
 from pmultiqc.modules.qpx.qpx_heatmap import calculate_qpx_heatmap
 from pmultiqc.modules.qpx.qpx_mass_error import calculate_mass_error
-from pmultiqc.modules.qpx.qpx_io import parse_qpx_parquet, select_columns
+from pmultiqc.modules.qpx.qpx_io import has_data, parse_qpx_parquet, select_columns
 from pmultiqc.modules.qpx.qpx_sections import (
     build_peptides_per_protein,
+    draw_qpx_pca,
     draw_qpx_search_engine_scores,
     calculate_contaminants,
     calculate_oversampling,
     calculate_search_engine_scores
 )
-from pmultiqc.modules.maxquant.maxquant_plots import draw_pg_pca
 from pmultiqc.modules.qpx.qpx_quant import (
     calculate_intensity_std,
     create_qpx_peptide_table,
@@ -293,11 +293,18 @@ class QpxModule(BasePMultiqcModule):
 
             # Summary Table & Pipeline Result Statistics
             # 'scan' is a list column (list<int32>), so .str[0] unwraps the scan number;
-            # the column itself is unhashable and cannot be grouped on. DIA-NN may write
-            # an empty list, which yields NaN and is dropped by groupby.
-            total_ms2_spectra_identified = self.id_df.groupby(
-                ["run", self.id_df["scan"].str[0]]
-            ).ngroups
+            # the column itself is unhashable and cannot be grouped on. It is optional,
+            # and DIA-NN may write an empty list, so fall back to counting rows.
+            if has_data(self.id_df, "scan"):
+                total_ms2_spectra_identified = self.id_df.groupby(
+                    ["run", self.id_df["scan"].str[0]]
+                ).ngroups
+            else:
+                total_ms2_spectra_identified = len(self.id_df)
+                log.info(
+                    "[Results Overview] No usable 'scan' column; reporting identified "
+                    "spectra as the identification count."
+                )
             total_peptide_count = self.id_df["sequence"].nunique()
 
         if self.pg_df_valid:
@@ -366,45 +373,55 @@ class QpxModule(BasePMultiqcModule):
         psm = None
 
         if self.id_df_valid:
-            psm = select_columns(
-                self.id_df,
-                ["run", "sequence", "charge", "modifications"],
-                "Identification Summary",
-            )
+            # 'modifications' is optional in the spec; without it we still want peptide
+            # length and missed cleavages, so it is added only when present.
+            wanted = ["run", "sequence", "charge"]
+            if "modifications" in self.id_df.columns:
+                wanted.append("modifications")
+            else:
+                log.info(
+                    "[Identification Summary] No 'modifications' column; the "
+                    "modifications plot will be skipped but the rest is unaffected."
+                )
+            psm = select_columns(self.id_df, wanted, "Identification Summary")
 
         if psm is not None:
 
             psm["pep_length"] = psm["sequence"].str.len()
 
-            unimod_data = UnimodDatabase()
-            psm["modifications"] = psm["modifications"].apply(
-                get_unimod_mod_qpx,
-                args=(unimod_data,)
-            )
+            has_mods = "modifications" in psm.columns
+            if has_mods:
+                unimod_data = UnimodDatabase()
+                psm["modifications"] = psm["modifications"].apply(
+                    get_unimod_mod_qpx,
+                    args=(unimod_data,)
+                )
 
             mod_plot_by_run = {}
             modified_cats = []
 
             for m, group in psm.groupby("run"):
 
-                mod_plot_dict, modified_cat = summarize_modifications(
-                    group[["sequence", "charge", "modifications"]].drop_duplicates()
-                )
-                mod_plot_by_run[m] = mod_plot_dict
-                modified_cats.extend(modified_cat)
+                if has_mods:
+                    mod_plot_dict, modified_cat = summarize_modifications(
+                        group[["sequence", "charge", "modifications"]].drop_duplicates()
+                    )
+                    mod_plot_by_run[m] = mod_plot_dict
+                    modified_cats.extend(modified_cat)
 
                 peptide_length[m] = group["pep_length"].value_counts().sort_index().to_dict()
 
-            mod_plot_by_sample = _sample_level_mods(
-                df=psm,
-                sdrf_file_df=self.file_df
-            )
+            if has_mods:
+                mod_plot_by_sample = _sample_level_mods(
+                    df=psm,
+                    sdrf_file_df=self.file_df
+                )
 
-            # Modifications
-            psm_modified["plot_data"] = [mod_plot_by_run, mod_plot_by_sample]
-            psm_modified["cats"] = list(
-                sorted(modified_cats, key=lambda x: (x == "Modified (Total)", x))
-            )
+                # Modifications
+                psm_modified["plot_data"] = [mod_plot_by_run, mod_plot_by_sample]
+                psm_modified["cats"] = list(
+                    sorted(modified_cats, key=lambda x: (x == "Modified (Total)", x))
+                )
 
             # Missed Cleavages
             missed_cleavages = get_missed_cleavages(psm, self.run_df, self.file_df)
@@ -581,11 +598,10 @@ class QpxModule(BasePMultiqcModule):
             pca_data = protein_intensity_pca(self.pg_df)
             if pca_data:
                 self._safe_draw(
-                    draw_pg_pca,
-                    name="draw_pg_pca",
+                    draw_qpx_pca,
+                    name="draw_qpx_pca",
                     sub_section=self.sub_sections["quantification"],
                     pca_data=pca_data,
-                    fig_type="raw_intensity",
                 )
 
         if self.feature_df_valid:
@@ -719,6 +735,10 @@ class QpxModule(BasePMultiqcModule):
             sample_df,
             file_df
         )
+
+        # Downstream sample-level plots gate on this flag; without it the design we
+        # just derived would be computed and then ignored.
+        self.enable_exp = True
 
     def _read_qpx_parquets(self, search_pattern, qpx_type):
         """Read every parquet file matching search_pattern and concatenate them.

--- a/pmultiqc/modules/qpx/qpx.py
+++ b/pmultiqc/modules/qpx/qpx.py
@@ -15,7 +15,8 @@ from pmultiqc.modules.common.common_utils import (
     evidence_rt_count
 )
 from pmultiqc.modules.common.plots.general import (
-    draw_exp_design
+    draw_exp_design,
+    draw_exp_design_tables
 )
 from pmultiqc.modules.common.plots.id import (
     draw_identi_num,
@@ -27,6 +28,7 @@ from pmultiqc.modules.common.plots.id import (
 
 from pmultiqc.modules.core.section_groups import add_group_modules
 from pmultiqc.modules.common.logging import get_logger
+from pmultiqc.modules.qpx.qpx_design import build_design_from_parquet
 from pmultiqc.modules.qpx.qpx_io import parse_qpx_parquet
 from pmultiqc.modules.qpx.qpx_plot import (
     draw_summary_table,
@@ -68,6 +70,7 @@ class QpxModule(BasePMultiqcModule):
         self.pg_df = None
         self.feature_df = None
         self.run_df = None
+        self.sample_parquet_df = None
         self.psm_df_valid = False
         self.pg_df_valid = False
         self.feature_df_valid = False
@@ -108,6 +111,7 @@ class QpxModule(BasePMultiqcModule):
         self.pg_df = self._read_qpx_parquets("pmultiqc/qpx_pg", "pg")
         self.feature_df = self._read_qpx_parquets("pmultiqc/qpx_feature", "feature")
         self.run_df = self._read_qpx_parquets("pmultiqc/qpx_run", None)
+        self.sample_parquet_df = self._read_qpx_parquets("pmultiqc/qpx_sample", None)
 
         self.psm_df_valid = self._is_valid(self.psm_df)
         self.pg_df_valid = self._is_valid(self.pg_df)
@@ -142,6 +146,11 @@ class QpxModule(BasePMultiqcModule):
                 self.sub_sections["experiment"],
                 self.exp_design
             )
+        else:
+            # No external design file: quantms.io describes the experiment itself, so
+            # derive it from run.parquet + sample.parquet instead of dropping every
+            # sample-level section.
+            self._draw_exp_design_from_parquet()
 
         # Results Overview
         self._safe_draw(
@@ -400,6 +409,33 @@ class QpxModule(BasePMultiqcModule):
                     rt_count_data=qpx_ids_over_rt,
                     report_type=""
                 )
+
+    def _draw_exp_design_from_parquet(self):
+        """Derive and render the experimental design from the quantms.io parquet tables.
+
+        Leaves the existing empty defaults in place if the tables cannot supply one,
+        so a project without them behaves exactly as before.
+        """
+        sample_df, file_df = build_design_from_parquet(self.run_df, self.sample_parquet_df)
+
+        if sample_df is None or file_df is None or file_df.empty:
+            log.info(
+                "[draw_plots] No experimental design file and none derivable from "
+                "run.parquet/sample.parquet; sample-level sections will be skipped."
+            )
+            return
+
+        (
+            self.sample_df,
+            self.file_df,
+            self.exp_design_runs,
+            self.is_bruker,
+            self.is_multi_conditions
+        ) = draw_exp_design_tables(
+            self.sub_sections["experiment"],
+            sample_df,
+            file_df
+        )
 
     def _read_qpx_parquets(self, search_pattern, qpx_type):
         """Read every parquet file matching search_pattern and concatenate them.

--- a/pmultiqc/modules/qpx/qpx.py
+++ b/pmultiqc/modules/qpx/qpx.py
@@ -65,6 +65,7 @@ from pmultiqc.modules.qpx.qpx_plot import (
 )
 from pmultiqc.modules.qpx.qpx_utils import (
     calculate_run_stat,
+    get_unambiguous_peptides,
     get_unimod_mod_qpx,
     get_pep_intensity,
     get_missed_cleavages
@@ -316,13 +317,16 @@ class QpxModule(BasePMultiqcModule):
 
             pg_by_run = self.pg_df.assign(_key=protein_group_key(self.pg_df))
             pg_prots_by_run = pg_by_run.groupby("run")["_key"].apply(set).to_dict()
+            unambiguous = get_unambiguous_peptides(
+                self.feature_df if self.feature_df_valid else self.id_df
+            )
             for run, psm_group in self.id_df.groupby("run"):
                 run_str = str(run)
                 prots = pg_prots_by_run.get(run_str, set())
                 (
                     stat_at_run[run_str],
                     data_per_run[run_str]
-                ) = calculate_run_stat(psm_group, prots)
+                ) = calculate_run_stat(psm_group, prots, unambiguous)
 
             num_table_at_sample = cal_num_table_at_sample(self.file_df, data_per_run)
 

--- a/pmultiqc/modules/qpx/qpx.py
+++ b/pmultiqc/modules/qpx/qpx.py
@@ -21,6 +21,7 @@ from pmultiqc.modules.common.plots.general import (
 )
 from pmultiqc.modules.common.dia_utils import draw_protein_table
 from pmultiqc.modules.common.plots.id import (
+    draw_delta_mass_da_ppm,
     draw_identi_num,
     draw_identification,
     draw_peptide_length_distribution,
@@ -32,6 +33,7 @@ from pmultiqc.modules.core.section_groups import add_group_modules
 from pmultiqc.modules.common.logging import get_logger
 from pmultiqc.modules.qpx.qpx_design import build_design_from_parquet
 from pmultiqc.modules.qpx.qpx_heatmap import calculate_qpx_heatmap
+from pmultiqc.modules.qpx.qpx_mass_error import calculate_mass_error
 from pmultiqc.modules.qpx.qpx_io import parse_qpx_parquet, select_columns
 from pmultiqc.modules.qpx.qpx_quant import (
     create_qpx_protein_table,
@@ -468,9 +470,31 @@ class QpxModule(BasePMultiqcModule):
 
     # Mass Error Trends
     def plot_mass_error(self):
-        log.info(
-            "mass_error_ppm column is entirely empty in psm.parquet, may need separate calculation."
-        )
+
+        log.info("[Mass Error] Starting generation...")
+
+        if not self.psm_df_valid:
+            return
+
+        ppm_dict, da_dict, _ = calculate_mass_error(self.psm_df)
+
+        if da_dict:
+            self._safe_draw(
+                draw_delta_mass_da_ppm,
+                name="draw_delta_mass_da",
+                sub_section=self.sub_sections["mass_error"],
+                delta_mass=da_dict,
+                delta_mass_type="Mass Error [Da]",
+            )
+
+        if ppm_dict:
+            self._safe_draw(
+                draw_delta_mass_da_ppm,
+                name="draw_delta_mass_ppm",
+                sub_section=self.sub_sections["mass_error"],
+                delta_mass=ppm_dict,
+                delta_mass_type="quantms_ppm",
+            )
 
     # RT Quality Control
     def plot_rt(self):

--- a/pmultiqc/modules/qpx/qpx.py
+++ b/pmultiqc/modules/qpx/qpx.py
@@ -32,7 +32,7 @@ from pmultiqc.modules.core.section_groups import add_group_modules
 from pmultiqc.modules.common.logging import get_logger
 from pmultiqc.modules.qpx.qpx_design import build_design_from_parquet
 from pmultiqc.modules.qpx.qpx_heatmap import calculate_qpx_heatmap
-from pmultiqc.modules.qpx.qpx_io import parse_qpx_parquet
+from pmultiqc.modules.qpx.qpx_io import parse_qpx_parquet, select_columns
 from pmultiqc.modules.qpx.qpx_quant import (
     create_qpx_protein_table,
     draw_protein_intensity,
@@ -300,10 +300,16 @@ class QpxModule(BasePMultiqcModule):
         psm_modified = {}
         peptide_length = {}
         missed_cleavages = {}
+        psm = None
 
         if self.psm_df_valid:
+            psm = select_columns(
+                self.psm_df,
+                ["run", "sequence", "charge", "modifications"],
+                "Identification Summary",
+            )
 
-            psm = self.psm_df[["run", "sequence", "charge", "modifications"]].copy()
+        if psm is not None:
 
             psm["pep_length"] = psm["sequence"].str.len()
 
@@ -392,8 +398,13 @@ class QpxModule(BasePMultiqcModule):
         qpx_pep_intensity = []
 
         if self.feature_df_valid:
-            feature_tmp = self.feature_df[["run", "peptidoform", "intensities"]].copy()
-            qpx_pep_intensity = get_pep_intensity(feature_tmp, self.file_df)
+            feature_tmp = select_columns(
+                self.feature_df,
+                ["run", "peptidoform", "intensities"],
+                "Peptide Intensity Distribution",
+            )
+            if feature_tmp is not None:
+                qpx_pep_intensity = get_pep_intensity(feature_tmp, self.file_df)
 
         if qpx_pep_intensity:
             self._safe_draw(
@@ -434,9 +445,11 @@ class QpxModule(BasePMultiqcModule):
         log.info("[MS2 and Spectral Stats] Starting generation...")
 
         if self.feature_df_valid:
-            feature_tmp = self.feature_df[["run", "charge"]].copy()
+            feature_tmp = select_columns(
+                self.feature_df, ["run", "charge"], "MS2 and Spectral Stats"
+            )
 
-            if not feature_tmp.empty:
+            if feature_tmp is not None and not feature_tmp.empty:
 
                 self._safe_draw(
                     draw_whole_exp_charge,
@@ -466,7 +479,10 @@ class QpxModule(BasePMultiqcModule):
 
         if self.psm_df_valid:
 
-            psm = self.psm_df[["run", "rt"]].copy()
+            psm = select_columns(self.psm_df, ["run", "rt"], "RT Quality Control")
+            if psm is None:
+                return
+
             psm["retention time"] = psm["rt"] / 60
             psm.rename(columns={"run": "raw file"}, inplace=True)
             qpx_ids_over_rt = evidence_rt_count(psm)

--- a/pmultiqc/modules/qpx/qpx.py
+++ b/pmultiqc/modules/qpx/qpx.py
@@ -37,6 +37,7 @@ from pmultiqc.modules.qpx.qpx_mass_error import calculate_mass_error
 from pmultiqc.modules.qpx.qpx_io import parse_qpx_parquet, select_columns
 from pmultiqc.modules.qpx.qpx_quant import (
     create_qpx_protein_table,
+    protein_group_key,
     draw_protein_intensity,
     get_protein_intensity
 )
@@ -93,6 +94,9 @@ class QpxModule(BasePMultiqcModule):
 
         self.cal_num_table_data = {}
         self.missed_cleavages_by_run = {}
+        self.id_df = None
+        self.id_source = None
+        self.id_df_valid = False
 
     def get_data(self):
 
@@ -127,6 +131,25 @@ class QpxModule(BasePMultiqcModule):
         self.psm_df_valid = self._is_valid(self.psm_df)
         self.pg_df_valid = self._is_valid(self.pg_df)
         self.feature_df_valid = self._is_valid(self.feature_df)
+
+        # DIA-NN-sourced QPX projects contain no psm.parquet at all (the PSM view is
+        # DDA-specific per the spec), but feature.parquet carries the same per-run
+        # identification fields. Everything PSM-derived reads this frame so a DIA
+        # project produces a populated report instead of an empty one.
+        if self.psm_df_valid:
+            self.id_df = self.psm_df
+            self.id_source = "psm"
+        elif self.feature_df_valid:
+            self.id_df = self.feature_df
+            self.id_source = "feature"
+            log.info(
+                "[get_data] No psm.parquet (expected for DIA-NN projects); "
+                "using feature.parquet for identification-level plots."
+            )
+        else:
+            self.id_df = None
+            self.id_source = None
+        self.id_df_valid = self.id_df is not None
 
         if self.psm_df_valid or self.pg_df_valid or self.feature_df_valid:
             log.info(
@@ -236,30 +259,35 @@ class QpxModule(BasePMultiqcModule):
         total_protein_identified = 0
         total_protein_quantified = 0
 
-        if self.psm_df_valid:
+        if self.id_df_valid:
 
             # Summary Table & Pipeline Result Statistics
-            # 'scan' is a list column (list<int32>) in psm.parquet, so .str[0] unwraps
-            # the scan number; the column itself is unhashable and cannot be grouped on.
-            total_ms2_spectra_identified = self.psm_df.groupby(
-                ["run", self.psm_df["scan"].str[0]]
+            # 'scan' is a list column (list<int32>), so .str[0] unwraps the scan number;
+            # the column itself is unhashable and cannot be grouped on. DIA-NN may write
+            # an empty list, which yields NaN and is dropped by groupby.
+            total_ms2_spectra_identified = self.id_df.groupby(
+                ["run", self.id_df["scan"].str[0]]
             ).ngroups
-            total_peptide_count = self.psm_df["sequence"].nunique()
+            total_peptide_count = self.id_df["sequence"].nunique()
 
         if self.pg_df_valid:
-            total_protein_identified = self.pg_df["anchor_protein"].nunique()
+            # Count protein groups by their accession set: anchor_protein is a display
+            # label and several groups may share one, so it undercounts.
+            pg_keys = protein_group_key(self.pg_df)
+            total_protein_identified = pg_keys.nunique()
 
             valid_intensity = self.pg_df["intensity"].notna() & (self.pg_df["intensity"] != "")
-            total_protein_quantified = self.pg_df.loc[valid_intensity, "anchor_protein"].nunique()
+            total_protein_quantified = pg_keys[valid_intensity].nunique()
 
         # Pipeline Result Statistics
-        if self.psm_df_valid and self.pg_df_valid:
+        if self.id_df_valid and self.pg_df_valid:
 
             stat_at_run = dict()
             data_per_run = dict()
 
-            pg_prots_by_run = self.pg_df.groupby("run")["anchor_protein"].apply(set).to_dict()
-            for run, psm_group in self.psm_df.groupby("run"):
+            pg_by_run = self.pg_df.assign(_key=protein_group_key(self.pg_df))
+            pg_prots_by_run = pg_by_run.groupby("run")["_key"].apply(set).to_dict()
+            for run, psm_group in self.id_df.groupby("run"):
                 run_str = str(run)
                 prots = pg_prots_by_run.get(run_str, set())
                 (
@@ -304,9 +332,9 @@ class QpxModule(BasePMultiqcModule):
         missed_cleavages = {}
         psm = None
 
-        if self.psm_df_valid:
+        if self.id_df_valid:
             psm = select_columns(
-                self.psm_df,
+                self.id_df,
                 ["run", "sequence", "charge", "modifications"],
                 "Identification Summary",
             )
@@ -373,7 +401,7 @@ class QpxModule(BasePMultiqcModule):
         log.info("[HeatMap] Starting generation...")
 
         heat_map_score, xnames, ynames = calculate_qpx_heatmap(
-            psm_df=self.psm_df if self.psm_df_valid else None,
+            psm_df=self.id_df if self.id_df_valid else None,
             pg_df=self.pg_df if self.pg_df_valid else None,
             feature_df=self.feature_df if self.feature_df_valid else None,
             missed_cleavages_by_run=self.missed_cleavages_by_run,
@@ -473,10 +501,10 @@ class QpxModule(BasePMultiqcModule):
 
         log.info("[Mass Error] Starting generation...")
 
-        if not self.psm_df_valid:
+        if not self.id_df_valid:
             return
 
-        ppm_dict, da_dict, _ = calculate_mass_error(self.psm_df)
+        ppm_dict, da_dict, _ = calculate_mass_error(self.id_df)
 
         if da_dict:
             self._safe_draw(
@@ -501,9 +529,9 @@ class QpxModule(BasePMultiqcModule):
 
         log.info("[RT Quality Control] Starting generation...")
 
-        if self.psm_df_valid:
+        if self.id_df_valid:
 
-            psm = select_columns(self.psm_df, ["run", "rt"], "RT Quality Control")
+            psm = select_columns(self.id_df, ["run", "rt"], "RT Quality Control")
             if psm is None:
                 return
 

--- a/pmultiqc/modules/qpx/qpx.py
+++ b/pmultiqc/modules/qpx/qpx.py
@@ -19,9 +19,13 @@ from pmultiqc.modules.common.plots.general import (
     draw_exp_design_tables,
     draw_heatmap
 )
-from pmultiqc.modules.common.dia_utils import draw_protein_table
+from pmultiqc.modules.common.dia_utils import draw_protein_table, draw_peptides_table
 from pmultiqc.modules.common.plots.id import (
     draw_delta_mass_da_ppm,
+    draw_num_pep_per_protein,
+    draw_oversampling,
+    draw_potential_contaminants,
+    draw_top_n_contaminants,
     draw_identi_num,
     draw_identification,
     draw_peptide_length_distribution,
@@ -35,9 +39,22 @@ from pmultiqc.modules.qpx.qpx_design import build_design_from_parquet
 from pmultiqc.modules.qpx.qpx_heatmap import calculate_qpx_heatmap
 from pmultiqc.modules.qpx.qpx_mass_error import calculate_mass_error
 from pmultiqc.modules.qpx.qpx_io import parse_qpx_parquet, select_columns
+from pmultiqc.modules.qpx.qpx_sections import (
+    build_peptides_per_protein,
+    draw_qpx_search_engine_scores,
+    calculate_contaminants,
+    calculate_oversampling,
+    calculate_search_engine_scores
+)
+from pmultiqc.modules.maxquant.maxquant_plots import draw_pg_pca
 from pmultiqc.modules.qpx.qpx_quant import (
+    calculate_intensity_std,
+    create_qpx_peptide_table,
     create_qpx_protein_table,
+    draw_intensity_std,
     protein_group_key,
+    protein_intensity_pca,
+    _peptides_per_protein,
     draw_protein_intensity,
     get_protein_intensity
 )
@@ -212,6 +229,18 @@ class QpxModule(BasePMultiqcModule):
             name="plot_quant_analysis"
         )
 
+        # Search Engine Scores
+        self._safe_draw(
+            self.plot_search_engine_scores,
+            name="plot_search_engine_scores"
+        )
+
+        # Contaminants
+        self._safe_draw(
+            self.plot_contaminants,
+            name="plot_contaminants"
+        )
+
         # MS2 and Spectral Stats
         self._safe_draw(
             self.plot_ms2_stats,
@@ -235,8 +264,8 @@ class QpxModule(BasePMultiqcModule):
             "experiment_sub_section": self.sub_sections["experiment"],
             "summary_sub_section": self.sub_sections["summary"],
             "identification_sub_section": self.sub_sections["identification"],
-            # "search_engine_sub_section": self.sub_sections["search_engine"],
-            # "contaminants_sub_section": self.sub_sections["contaminants"],
+            "search_engine_sub_section": self.sub_sections["search_engine"],
+            "contaminants_sub_section": self.sub_sections["contaminants"],
             "quantification_sub_section": self.sub_sections["quantification"],
             # "ms1_sub_section": self.sub_sections["ms1"],
             "ms2_sub_section": self.sub_sections["ms2"],
@@ -386,6 +415,31 @@ class QpxModule(BasePMultiqcModule):
             msms_identified_rate=None,
         )
 
+        # Number of Peptides identified Per Protein
+        if self.feature_df_valid:
+            pep_plot = build_peptides_per_protein(
+                self.feature_df, _peptides_per_protein(self.feature_df)
+            )
+            if pep_plot is not None:
+                self._safe_draw(
+                    draw_num_pep_per_protein,
+                    name="draw_num_pep_per_protein",
+                    sub_sections=self.sub_sections["identification"],
+                    pep_plot=pep_plot,
+                )
+
+        # MS/MS Counts Per 3D-peak
+        oversampling, oversampling_cats = calculate_oversampling(self.id_df)
+        if oversampling:
+            self._safe_draw(
+                draw_oversampling,
+                name="draw_oversampling",
+                sub_section=self.sub_sections["ms2"],
+                oversampling=oversampling,
+                oversampling_plot=oversampling_cats,
+                data_type="qpx",
+            )
+
         # Peptide Length Distribution
         if peptide_length:
            self._safe_draw(
@@ -419,6 +473,55 @@ class QpxModule(BasePMultiqcModule):
             heatmap_ynames=ynames,
             report_type="",
         )
+
+    # Search Engine Scores
+    def plot_search_engine_scores(self):
+
+        log.info("[Search Engine Scores] Starting generation...")
+
+        if not self.id_df_valid:
+            return
+
+        plot_data, score_name = calculate_search_engine_scores(self.id_df)
+        if not plot_data:
+            return
+
+        self._safe_draw(
+            draw_qpx_search_engine_scores,
+            name="draw_qpx_search_engine_scores",
+            sub_section=self.sub_sections["search_engine"],
+            plot_data=plot_data,
+            score_name=score_name,
+        )
+
+    # Contaminants
+    def plot_contaminants(self):
+
+        log.info("[Contaminants] Starting generation...")
+
+        if not self.pg_df_valid:
+            return
+
+        per_run, top_n = calculate_contaminants(
+            self.pg_df, config.kwargs.get("contaminant_affix", "CONT")
+        )
+
+        if per_run:
+            self._safe_draw(
+                draw_potential_contaminants,
+                name="draw_potential_contaminants",
+                sub_section=self.sub_sections["contaminants"],
+                contaminant_percent=per_run,
+                report_type="qpx",
+            )
+
+        if top_n:
+            self._safe_draw(
+                draw_top_n_contaminants,
+                name="draw_top_n_contaminants",
+                sub_section=self.sub_sections["contaminants"],
+                top_contaminants_data=top_n,
+            )
 
     # Quantification Analysis
     def plot_quant_analysis(self):
@@ -469,6 +572,44 @@ class QpxModule(BasePMultiqcModule):
                 sub_section=self.sub_sections["quantification"],
                 plot_data=get_protein_intensity(self.pg_df, self.file_df),
             )
+
+            # PCA of protein intensity
+            pca_data = protein_intensity_pca(self.pg_df)
+            if pca_data:
+                self._safe_draw(
+                    draw_pg_pca,
+                    name="draw_pg_pca",
+                    sub_section=self.sub_sections["quantification"],
+                    pca_data=pca_data,
+                    fig_type="raw_intensity",
+                )
+
+        if self.feature_df_valid:
+            # Peptides Quantification Table
+            peptide_table, peptide_headers = create_qpx_peptide_table(
+                self.feature_df, self.sample_df, self.file_df
+            )
+            if peptide_table:
+                self._safe_draw(
+                    draw_peptides_table,
+                    name="draw_peptides_table",
+                    sub_section=self.sub_sections["quantification"],
+                    table_data=peptide_table,
+                    headers=peptide_headers,
+                    report_type="qpx",
+                )
+
+            # Standard Deviation of Intensity
+            std_data = calculate_intensity_std(
+                self.feature_df, self.sample_df, self.file_df
+            )
+            if std_data:
+                self._safe_draw(
+                    draw_intensity_std,
+                    name="draw_intensity_std",
+                    sub_section=self.sub_sections["quantification"],
+                    box_data=std_data,
+                )
 
     # MS2 and Spectral Stats
     def plot_ms2_stats(self):

--- a/pmultiqc/modules/qpx/qpx.py
+++ b/pmultiqc/modules/qpx/qpx.py
@@ -16,8 +16,10 @@ from pmultiqc.modules.common.common_utils import (
 )
 from pmultiqc.modules.common.plots.general import (
     draw_exp_design,
-    draw_exp_design_tables
+    draw_exp_design_tables,
+    draw_heatmap
 )
+from pmultiqc.modules.common.dia_utils import draw_protein_table
 from pmultiqc.modules.common.plots.id import (
     draw_identi_num,
     draw_identification,
@@ -29,7 +31,13 @@ from pmultiqc.modules.common.plots.id import (
 from pmultiqc.modules.core.section_groups import add_group_modules
 from pmultiqc.modules.common.logging import get_logger
 from pmultiqc.modules.qpx.qpx_design import build_design_from_parquet
+from pmultiqc.modules.qpx.qpx_heatmap import calculate_qpx_heatmap
 from pmultiqc.modules.qpx.qpx_io import parse_qpx_parquet
+from pmultiqc.modules.qpx.qpx_quant import (
+    create_qpx_protein_table,
+    draw_protein_intensity,
+    get_protein_intensity
+)
 from pmultiqc.modules.qpx.qpx_plot import (
     draw_summary_table,
     draw_whole_exp_charge,
@@ -82,6 +90,7 @@ class QpxModule(BasePMultiqcModule):
         self.is_multi_conditions = False
 
         self.cal_num_table_data = {}
+        self.missed_cleavages_by_run = {}
 
     def get_data(self):
 
@@ -162,6 +171,14 @@ class QpxModule(BasePMultiqcModule):
         self._safe_draw(
             self.plot_id_summary,
             name="plot_id_summary"
+        )
+
+        # QC HeatMap. Drawn after the identification step because it reuses the
+        # missed-cleavage counts computed there; add_sub_section places it by order,
+        # so it still appears inside the Results Overview section.
+        self._safe_draw(
+            self.plot_heatmap,
+            name="plot_heatmap"
         )
 
         # Quantification Analysis
@@ -322,6 +339,8 @@ class QpxModule(BasePMultiqcModule):
 
             # Missed Cleavages
             missed_cleavages = get_missed_cleavages(psm, self.run_df, self.file_df)
+            # Reused by the QC heatmap, which is rendered after this step.
+            self.missed_cleavages_by_run = missed_cleavages.get("ms_runs", {})
 
         draw_identification(
             sub_sections=self.sub_sections["identification"],
@@ -340,6 +359,31 @@ class QpxModule(BasePMultiqcModule):
                 plot_data=peptide_length
            )
 
+    # QC HeatMap
+    def plot_heatmap(self):
+
+        log.info("[HeatMap] Starting generation...")
+
+        heat_map_score, xnames, ynames = calculate_qpx_heatmap(
+            psm_df=self.psm_df if self.psm_df_valid else None,
+            pg_df=self.pg_df if self.pg_df_valid else None,
+            feature_df=self.feature_df if self.feature_df_valid else None,
+            missed_cleavages_by_run=self.missed_cleavages_by_run,
+            contaminant_affix=config.kwargs.get("contaminant_affix", "CONT"),
+        )
+
+        if not heat_map_score:
+            return
+
+        draw_heatmap(
+            sub_sections=self.sub_sections["summary"],
+            hm_colors=self.heatmap_color_list,
+            heatmap_data=heat_map_score,
+            heatmap_xnames=xnames,
+            heatmap_ynames=ynames,
+            report_type="",
+        )
+
     # Quantification Analysis
     def plot_quant_analysis(self):
 
@@ -357,6 +401,32 @@ class QpxModule(BasePMultiqcModule):
                 name="draw_peptide_intensity",
                 sub_section=self.sub_sections["quantification"],
                 plot_data=qpx_pep_intensity
+            )
+
+        if self.pg_df_valid:
+            # Protein Quantification Table
+            table_data, headers = create_qpx_protein_table(
+                pg_df=self.pg_df,
+                feature_df=self.feature_df if self.feature_df_valid else None,
+                sample_df=self.sample_df,
+                file_df=self.file_df,
+            )
+            if table_data:
+                self._safe_draw(
+                    draw_protein_table,
+                    name="draw_protein_table",
+                    sub_sections=self.sub_sections["quantification"],
+                    table_data=table_data,
+                    headers=headers,
+                    report_type="qpx",
+                )
+
+            # Protein Intensity Distribution
+            self._safe_draw(
+                draw_protein_intensity,
+                name="draw_protein_intensity",
+                sub_section=self.sub_sections["quantification"],
+                plot_data=get_protein_intensity(self.pg_df, self.file_df),
             )
 
     # MS2 and Spectral Stats

--- a/pmultiqc/modules/qpx/qpx_design.py
+++ b/pmultiqc/modules/qpx/qpx_design.py
@@ -1,0 +1,249 @@
+"""Reconstruct an OpenMS-style experimental design from quantms.io parquet tables.
+
+A quantms.io project is self-describing: ``run.parquet`` carries the run -> sample
+mapping (including label, fraction and replicate numbers) and ``sample.parquet``
+carries the sample characteristics. This module turns those two tables into the
+same ``(sample_df, file_df)`` pair that :func:`read_openms_design` produces from an
+external experimental-design TSV, so the sample-level sections of the report work
+without one.
+
+Target schema (matching ``read_openms_design``)::
+
+    sample_df: Sample, Condition, BioReplicate
+    file_df:   FractionGroup, Fraction, Label, Sample, Filename, Run
+"""
+
+from __future__ import absolute_import
+
+import re
+
+import pandas as pd
+
+from pmultiqc.modules.common.common_utils import file_prefix
+from pmultiqc.modules.common.logging import get_logger
+
+
+log = get_logger("pmultiqc.modules.qpx.qpx_design")
+
+# Isobaric channel -> numeric label, matching the ordering used elsewhere in pmultiqc.
+CHANNEL_TO_LABEL = {
+    "TMT126": 1, "TMT127N": 2, "TMT127C": 3, "TMT128N": 4, "TMT128C": 5,
+    "TMT129N": 6, "TMT129C": 7, "TMT130N": 8, "TMT130C": 9, "TMT131": 10,
+    "TMT131C": 11, "TMT132N": 12, "TMT132C": 13, "TMT133N": 14, "TMT133C": 15,
+    "TMT134N": 16,
+    "ITRAQ113": 1, "ITRAQ114": 2, "ITRAQ115": 3, "ITRAQ116": 4,
+    "ITRAQ117": 5, "ITRAQ118": 6, "ITRAQ119": 7, "ITRAQ121": 8,
+}
+
+# Sample characteristics that never distinguish samples, so are never a Condition.
+_NON_CONDITION_COLUMNS = {"sample_accession", "sample_description"}
+
+
+def build_design_from_parquet(run_df, sample_df_raw):
+    """Build ``(sample_df, file_df)`` from the run and sample parquet tables.
+
+    Returns ``(None, None)`` when the tables cannot supply a usable design, so the
+    caller can fall back to its existing behaviour rather than emit a broken table.
+    """
+    if run_df is None or getattr(run_df, "empty", True):
+        return None, None
+    if "samples" not in run_df.columns or "run_file_name" not in run_df.columns:
+        log.debug("run.parquet lacks 'samples'/'run_file_name'; cannot derive a design")
+        return None, None
+
+    accessions = _sample_accessions(run_df, sample_df_raw)
+    if not accessions:
+        log.debug("no sample accessions found in run.parquet; cannot derive a design")
+        return None, None
+    sample_numbers = _number_samples(accessions)
+
+    file_rows = []
+    bio_replicates = {}
+    for run in run_df.itertuples():
+        run_file_name = getattr(run, "run_file_name", None)
+        if not run_file_name:
+            continue
+
+        filename = getattr(run, "file_name", None) or run_file_name
+        fraction = _as_int(getattr(run, "fraction", None), default=1)
+
+        for entry in _iter_samples(getattr(run, "samples", None)):
+            accession = entry.get("sample_accession")
+            number = sample_numbers.get(accession)
+            if number is None:
+                continue
+
+            bio_replicates.setdefault(
+                number, _as_int(entry.get("biological_replicate"), default=1)
+            )
+            file_rows.append(
+                {
+                    # quantms.io has no explicit fraction group; runs of one sample
+                    # form the group, so the sample number stands in for it.
+                    "FractionGroup": number,
+                    "Fraction": fraction,
+                    "Label": _label_number(entry.get("label")),
+                    "Sample": number,
+                    "Filename": filename,
+                    "Run": file_prefix(run_file_name),
+                }
+            )
+
+    if not file_rows:
+        log.debug("run.parquet produced no run/sample rows; cannot derive a design")
+        return None, None
+
+    file_df = pd.DataFrame(file_rows).drop_duplicates().reset_index(drop=True)
+
+    conditions = _conditions(sample_df_raw, accessions)
+    sample_df = pd.DataFrame(
+        [
+            {
+                "Sample": number,
+                "Condition": conditions.get(accession, "not available"),
+                "BioReplicate": bio_replicates.get(number, 1),
+            }
+            for accession, number in sorted(sample_numbers.items(), key=lambda kv: kv[1])
+            if number in set(file_df["Sample"])
+        ]
+    ).reset_index(drop=True)
+
+    log.info(
+        "Derived experimental design from quantms.io parquet: "
+        f"{len(sample_df)} sample(s), {len(file_df)} run/sample row(s)."
+    )
+    return sample_df, file_df
+
+
+def _iter_samples(cell):
+    """Yield the per-sample dicts held in a run's 'samples' list column."""
+    if cell is None:
+        return
+    try:
+        entries = list(cell)
+    except TypeError:
+        return
+    for entry in entries:
+        if isinstance(entry, dict):
+            yield entry
+
+
+def _sample_accessions(run_df, sample_df_raw):
+    """Collect sample accessions, preferring sample.parquet's order when available."""
+    ordered = []
+    if sample_df_raw is not None and not getattr(sample_df_raw, "empty", True):
+        if "sample_accession" in sample_df_raw.columns:
+            ordered = [str(a) for a in sample_df_raw["sample_accession"].dropna()]
+
+    seen = set(ordered)
+    for cell in run_df["samples"]:
+        for entry in _iter_samples(cell):
+            accession = entry.get("sample_accession")
+            if accession is not None and str(accession) not in seen:
+                seen.add(str(accession))
+                ordered.append(str(accession))
+    return ordered
+
+
+def _number_samples(accessions):
+    """Map each accession to the integer Sample id the report tables require.
+
+    Downstream code does ``file_df["Sample"].astype(int)``, so a numeric id is
+    mandatory. A trailing number in the accession ("Sample 3" -> 3) is used when it
+    is unique across samples; otherwise samples are numbered by their order.
+    """
+    trailing = {}
+    for accession in accessions:
+        match = re.search(r"(\d+)\s*$", str(accession))
+        trailing[accession] = int(match.group(1)) if match else None
+
+    values = list(trailing.values())
+    if all(v is not None for v in values) and len(set(values)) == len(values):
+        return {a: int(v) for a, v in trailing.items()}
+
+    return {accession: i for i, accession in enumerate(accessions, start=1)}
+
+
+def _label_number(label):
+    """Map a quantms.io label ('LFQ', 'TMT126', ...) to its numeric channel."""
+    if label is None:
+        return 1
+    key = str(label).strip().upper().replace("-", "").replace("_", "")
+    if key in CHANNEL_TO_LABEL:
+        return CHANNEL_TO_LABEL[key]
+    if key.isdigit():
+        return int(key)
+    # LFQ (and anything unrecognised) is a single channel.
+    return 1
+
+
+def _as_int(value, default):
+    try:
+        if value is None or (isinstance(value, float) and pd.isna(value)):
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _conditions(sample_df_raw, accessions):
+    """Derive a Condition per sample from the characteristics that actually vary.
+
+    quantms design files put a plain characteristic value in MSstats_Condition (e.g.
+    the cell line). We mirror that: a single varying characteristic is used as-is,
+    and several are emitted as ``key=value;key=value``, the multi-condition form
+    ``draw_exp_design`` already understands.
+    """
+    if sample_df_raw is None or getattr(sample_df_raw, "empty", True):
+        return {}
+    if "sample_accession" not in sample_df_raw.columns:
+        return {}
+
+    df = sample_df_raw.drop_duplicates(subset=["sample_accession"])
+    df = df[df["sample_accession"].notna()]
+    if df.empty:
+        return {}
+
+    varying = [
+        column
+        for column in df.columns
+        if column not in _NON_CONDITION_COLUMNS
+        and df[column].notna().any()
+        and df[column].astype(str).nunique() > 1
+    ]
+
+    if len(accessions) <= 1 or not varying:
+        # Nothing distinguishes the samples; fall back to a constant characteristic
+        # so the column still carries something meaningful.
+        constant = [
+            column
+            for column in df.columns
+            if column not in _NON_CONDITION_COLUMNS and df[column].notna().any()
+        ]
+        if not constant:
+            return {}
+        column = constant[0]
+        return {
+            str(r["sample_accession"]): str(r[column])
+            for _, r in df.iterrows()
+            if pd.notna(r[column])
+        }
+
+    conditions = {}
+    for _, row in df.iterrows():
+        if len(varying) == 1:
+            value = row[varying[0]]
+            conditions[str(row["sample_accession"])] = (
+                str(value) if pd.notna(value) else "not available"
+            )
+        else:
+            parts = [
+                f"{column}={row[column]}"
+                for column in varying
+                if pd.notna(row[column]) and "=" not in str(row[column])
+                and ";" not in str(row[column])
+            ]
+            conditions[str(row["sample_accession"])] = (
+                ";".join(parts) if parts else "not available"
+            )
+    return conditions

--- a/pmultiqc/modules/qpx/qpx_heatmap.py
+++ b/pmultiqc/modules/qpx/qpx_heatmap.py
@@ -95,13 +95,28 @@ def _contaminant_scores(pg_df, contaminant_affix):
     df = pg_df[["run", "intensity"]].copy()
     df["intensity"] = pd.to_numeric(df["intensity"], errors="coerce")
 
+    # The spec makes 'contaminant' nullable and DIA-NN/FragPipe emit None outright, so
+    # null means "unknown", not "not a contaminant". Reporting 100% clean from an
+    # all-null column would be inventing a result: fall through to the accession affix,
+    # and if that is unavailable too, drop the metric.
     if "contaminant" in pg_df.columns and pg_df["contaminant"].notna().any():
-        df["is_contaminant"] = pg_df["contaminant"].fillna(False).astype(bool)
+        flags = pg_df["contaminant"]
+        if flags.isna().any():
+            log.debug(
+                "pg 'contaminant' is partially null; unknown rows counted as non-contaminant."
+            )
+        df["is_contaminant"] = flags.fillna(False).astype(bool)
+    elif "pg_accessions" in pg_df.columns and contaminant_affix:
+        df["is_contaminant"] = _accessions_match(pg_df["pg_accessions"], contaminant_affix)
     elif "anchor_protein" in pg_df.columns and contaminant_affix:
         df["is_contaminant"] = (
             pg_df["anchor_protein"].astype(str).str.contains(contaminant_affix, regex=False)
         )
     else:
+        log.info(
+            "[HeatMap] Contaminants omitted: 'contaminant' is entirely null (unknown for "
+            "this producer) and no accession column is available to match the affix."
+        )
         return {}
 
     df = df.dropna(subset=["intensity"])
@@ -116,6 +131,19 @@ def _contaminant_scores(pg_df, contaminant_affix):
         contaminated = group.loc[group["is_contaminant"], "intensity"].sum()
         result[str(run)] = float(max(0.0, 1.0 - contaminated / total))
     return result
+
+
+def _accessions_match(accessions, affix):
+    """Match an affix against a list<string> accession column."""
+    def matches(cell):
+        if cell is None:
+            return False
+        try:
+            return any(affix in str(a) for a in cell)
+        except TypeError:
+            return affix in str(cell)
+
+    return accessions.apply(matches)
 
 
 def _peptide_intensity_scores(feature_df):

--- a/pmultiqc/modules/qpx/qpx_heatmap.py
+++ b/pmultiqc/modules/qpx/qpx_heatmap.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 from pmultiqc.modules.common.logging import get_logger
 from pmultiqc.modules.common.stats import cal_hm_charge, nanmedian, qual_uniform
+from pmultiqc.modules.qpx.qpx_sections import resolve_contaminant_flags
 
 
 log = get_logger("pmultiqc.modules.qpx.qpx_heatmap")
@@ -95,29 +96,16 @@ def _contaminant_scores(pg_df, contaminant_affix):
     df = pg_df[["run", "intensity"]].copy()
     df["intensity"] = pd.to_numeric(df["intensity"], errors="coerce")
 
-    # The spec makes 'contaminant' nullable and DIA-NN/FragPipe emit None outright, so
-    # null means "unknown", not "not a contaminant". Reporting 100% clean from an
-    # all-null column would be inventing a result: fall through to the accession affix,
-    # and if that is unavailable too, drop the metric.
-    if "contaminant" in pg_df.columns and pg_df["contaminant"].notna().any():
-        flags = pg_df["contaminant"]
-        if flags.isna().any():
-            log.debug(
-                "pg 'contaminant' is partially null; unknown rows counted as non-contaminant."
-            )
-        df["is_contaminant"] = flags.fillna(False).astype(bool)
-    elif "pg_accessions" in pg_df.columns and contaminant_affix:
-        df["is_contaminant"] = _accessions_match(pg_df["pg_accessions"], contaminant_affix)
-    elif "anchor_protein" in pg_df.columns and contaminant_affix:
-        df["is_contaminant"] = (
-            pg_df["anchor_protein"].astype(str).str.contains(contaminant_affix, regex=False)
-        )
-    else:
+    # Resolved by the shared helper so this metric and the Contaminants section can
+    # never disagree: the producer flag unioned with a case-insensitive affix match.
+    flags = resolve_contaminant_flags(pg_df, contaminant_affix)
+    if flags is None:
         log.info(
-            "[HeatMap] Contaminants omitted: 'contaminant' is entirely null (unknown for "
-            "this producer) and no accession column is available to match the affix."
+            "[HeatMap] Contaminants omitted: the 'contaminant' flag is entirely null "
+            "(unknown for this producer) and no accession column matches the affix."
         )
         return {}
+    df["is_contaminant"] = flags
 
     df = df.dropna(subset=["intensity"])
     if df.empty:

--- a/pmultiqc/modules/qpx/qpx_heatmap.py
+++ b/pmultiqc/modules/qpx/qpx_heatmap.py
@@ -1,0 +1,228 @@
+"""QC heatmap scores for the QPX module, computed from the quantms.io parquet tables.
+
+Mirrors the DDA heatmap that quantms/maxquant/mzIdentML already draw, using the same
+formulas so scores are comparable across report types. Every metric is optional: one
+whose input column is absent or empty is dropped from the heatmap rather than emitted
+as a misleading flat row.
+"""
+
+from __future__ import absolute_import
+
+import numpy as np
+import pandas as pd
+
+from pmultiqc.modules.common.logging import get_logger
+from pmultiqc.modules.common.stats import cal_hm_charge, nanmedian, qual_uniform
+
+
+log = get_logger("pmultiqc.modules.qpx.qpx_heatmap")
+
+# quantms scales the median intensity against this reference before clamping to 1.
+INTENSITY_REFERENCE = 2 ** 23
+
+# Display order, matching the quantms DDA heatmap.
+METRIC_ORDER = [
+    "Contaminants",
+    "Peptide Intensity",
+    "Charge",
+    "Missed Cleavages",
+    "Missed Cleavages Var",
+    "ID rate over RT",
+    "MS2 OverSampling",
+    "Pep Missing Values",
+]
+
+
+def calculate_qpx_heatmap(psm_df, pg_df, feature_df, missed_cleavages_by_run, contaminant_affix):
+    """Build ``(heat_map_score, xnames, ynames)`` for :func:`draw_heatmap`.
+
+    Returns ``([], [], [])`` when nothing can be computed, so the caller can skip the
+    plot entirely.
+    """
+    if psm_df is None or getattr(psm_df, "empty", True) or "run" not in psm_df.columns:
+        return [], [], []
+
+    runs = sorted({str(r) for r in psm_df["run"].dropna()})
+    if not runs:
+        return [], [], []
+
+    scores = {
+        "Contaminants": _contaminant_scores(pg_df, contaminant_affix),
+        "Peptide Intensity": _peptide_intensity_scores(feature_df),
+        "Charge": _charge_scores(psm_df),
+        "Missed Cleavages": _missed_cleavage_scores(missed_cleavages_by_run),
+        "ID rate over RT": _id_rate_over_rt_scores(psm_df),
+        "MS2 OverSampling": _oversampling_scores(psm_df),
+        "Pep Missing Values": _pep_missing_value_scores(psm_df),
+    }
+    scores["Missed Cleavages Var"] = _variance_scores(scores["Missed Cleavages"])
+
+    # Keep only metrics that cover every run, so no cell is silently invented.
+    xnames = [
+        metric
+        for metric in METRIC_ORDER
+        if scores.get(metric) and all(run in scores[metric] for run in runs)
+    ]
+    dropped = [
+        metric
+        for metric in METRIC_ORDER
+        if metric not in xnames
+    ]
+    if dropped:
+        log.info(
+            "[HeatMap] Metrics not available for this project and omitted: "
+            f"{', '.join(dropped)}."
+        )
+    if not xnames:
+        log.warning("[HeatMap] No metrics could be computed; skipping the heatmap.")
+        return [], [], []
+
+    heat_map_score = [[float(scores[metric][run]) for metric in xnames] for run in runs]
+    return heat_map_score, xnames, runs
+
+
+def _contaminant_scores(pg_df, contaminant_affix):
+    """1 - (contaminant intensity / total intensity) per run.
+
+    Prefers the explicit ``contaminant`` flag, falling back to matching the affix
+    against the protein accession the way the other plugins do.
+    """
+    if pg_df is None or getattr(pg_df, "empty", True):
+        return {}
+    if "run" not in pg_df.columns or "intensity" not in pg_df.columns:
+        return {}
+
+    df = pg_df[["run", "intensity"]].copy()
+    df["intensity"] = pd.to_numeric(df["intensity"], errors="coerce")
+
+    if "contaminant" in pg_df.columns and pg_df["contaminant"].notna().any():
+        df["is_contaminant"] = pg_df["contaminant"].fillna(False).astype(bool)
+    elif "anchor_protein" in pg_df.columns and contaminant_affix:
+        df["is_contaminant"] = (
+            pg_df["anchor_protein"].astype(str).str.contains(contaminant_affix, regex=False)
+        )
+    else:
+        return {}
+
+    df = df.dropna(subset=["intensity"])
+    if df.empty:
+        return {}
+
+    result = {}
+    for run, group in df.groupby("run"):
+        total = group["intensity"].sum()
+        if total <= 0:
+            continue
+        contaminated = group.loc[group["is_contaminant"], "intensity"].sum()
+        result[str(run)] = float(max(0.0, 1.0 - contaminated / total))
+    return result
+
+
+def _peptide_intensity_scores(feature_df):
+    """min(1, median(feature intensity) / 2**23) per run."""
+    if feature_df is None or getattr(feature_df, "empty", True):
+        return {}
+    if "run" not in feature_df.columns or "intensities" not in feature_df.columns:
+        return {}
+
+    exploded = feature_df[["run", "intensities"]].dropna(subset=["intensities"])
+    exploded = exploded.explode("intensities").dropna(subset=["intensities"])
+    if exploded.empty:
+        return {}
+
+    exploded["intensity"] = pd.to_numeric(
+        exploded["intensities"].str.get("intensity"), errors="coerce"
+    )
+    exploded = exploded[exploded["intensity"] > 0]
+    if exploded.empty:
+        return {}
+
+    result = {}
+    for run, group in exploded.groupby("run"):
+        median = nanmedian(group["intensity"].to_numpy(), np.float64(0.0))
+        result[str(run)] = float(min(1.0, median / INTENSITY_REFERENCE))
+    return result
+
+
+def _charge_scores(psm_df):
+    if "charge" not in psm_df.columns or psm_df["charge"].isna().all():
+        return {}
+    return {str(k): float(v) for k, v in cal_hm_charge(psm_df, "run", "charge").items()}
+
+
+def _missed_cleavage_scores(missed_cleavages_by_run):
+    """Fraction of PSMs with zero missed cleavages, per run."""
+    if not missed_cleavages_by_run:
+        return {}
+
+    result = {}
+    for run, counts in missed_cleavages_by_run.items():
+        if not isinstance(counts, dict):
+            continue
+        total = sum(counts.values())
+        if total <= 0:
+            continue
+        # Keys may arrive as int or str depending on how the counts were built.
+        zero = counts.get(0, counts.get("0", 0))
+        result[str(run)] = float(zero / total)
+    return result
+
+
+def _variance_scores(base_scores):
+    """1 - |value - median| across runs, as used for Missed Cleavages Var."""
+    if not base_scores:
+        return {}
+    median = np.median(list(base_scores.values()))
+    return {
+        run: float(max(0.0, 1.0 - abs(value - median)))
+        for run, value in base_scores.items()
+    }
+
+
+def _id_rate_over_rt_scores(psm_df):
+    if "rt" not in psm_df.columns or psm_df["rt"].isna().all():
+        return {}
+    return {
+        str(run): float(qual_uniform(group["rt"]))
+        for run, group in psm_df[["run", "rt"]].groupby("run")
+    }
+
+
+def _oversampling_scores(psm_df):
+    """Fraction of precursors identified exactly once (MS2 oversampling)."""
+    if "peptidoform" not in psm_df.columns or "charge" not in psm_df.columns:
+        return {}
+
+    df = psm_df[["run", "peptidoform", "charge"]].dropna(subset=["peptidoform"])
+    if df.empty:
+        return {}
+
+    result = {}
+    for run, group in df.groupby("run"):
+        counts = group.groupby(["peptidoform", "charge"]).size()
+        if counts.empty:
+            continue
+        result[str(run)] = float(min(1.0, (counts == 1).sum() / len(counts)))
+    return result
+
+
+def _pep_missing_value_scores(psm_df):
+    """Share of the project's peptidoforms that each run identifies."""
+    if "peptidoform" not in psm_df.columns:
+        return {}
+
+    df = psm_df[["run", "peptidoform"]].dropna(subset=["peptidoform"])
+    if df.empty:
+        return {}
+
+    global_peptidoforms = set(df["peptidoform"])
+    if not global_peptidoforms:
+        return {}
+
+    return {
+        str(run): float(
+            min(1.0, len(set(group["peptidoform"]) & global_peptidoforms)
+                / len(global_peptidoforms))
+        )
+        for run, group in df.groupby("run")
+    }

--- a/pmultiqc/modules/qpx/qpx_io.py
+++ b/pmultiqc/modules/qpx/qpx_io.py
@@ -32,7 +32,12 @@ QPX_COLUMNS = {
     "feature": [
         "feature_id", "sequence", "peptidoform",
         "charge", "is_decoy", "run_file_name",
-        "intensities", "anchor_protein"
+        "intensities", "anchor_protein",
+        # Needed so peptide counts key on the same protein-group identity as pg.parquet;
+        # keying on anchor_protein alone silently loses every multi-accession group.
+        # Optional (absent in older writers); skipped automatically when missing.
+        "pg_accessions", "modifications", "rt",
+        "calculated_mz", "observed_mz", "unique"
     ]
 }
 

--- a/pmultiqc/modules/qpx/qpx_io.py
+++ b/pmultiqc/modules/qpx/qpx_io.py
@@ -37,6 +37,30 @@ QPX_COLUMNS = {
 }
 
 
+def has_data(df, *columns):
+    """True only if every named column exists AND holds at least one non-null value.
+
+    quantms.io declares many fields as optional, and different producers populate
+    different subsets -- a DIA-NN-sourced project fills fields a DDA/OpenMS one leaves
+    null, and vice versa. Several columns are present in the schema but entirely empty
+    in real files (mass_error_ppm, missed_cleavages, unique, ...). Presence is therefore
+    not usability: every section must test the data, not the schema.
+    """
+    if df is None or getattr(df, "empty", True):
+        return False
+
+    for column in columns:
+        if column not in df.columns:
+            return False
+        try:
+            if not df[column].notna().any():
+                return False
+        except (TypeError, ValueError):
+            return False
+
+    return True
+
+
 def select_columns(df, columns, context):
     """Return ``df[columns]`` only if every column is present, else ``None``.
 

--- a/pmultiqc/modules/qpx/qpx_io.py
+++ b/pmultiqc/modules/qpx/qpx_io.py
@@ -4,6 +4,8 @@ from pmultiqc.modules.common.logging import get_logger
 from multiqc import config
 
 import pandas as pd
+import pyarrow.parquet as pq
+
 from pmultiqc.modules.common.file_utils import file_prefix
 
 
@@ -23,7 +25,9 @@ QPX_COLUMNS = {
     "pg": [
         "pg_accessions", "anchor_protein",
         "grouped_runs", "global_qvalue",
-        "intensity", "is_decoy"
+        "intensity", "is_decoy",
+        # Optional (absent in older writers); skipped automatically when missing.
+        "contaminant"
     ],
     "feature": [
         "feature_id", "sequence", "peptidoform",
@@ -39,8 +43,18 @@ def parse_qpx_parquet(file_path, qpx_type):
     if "is_decoy" not in req_columns:
         req_columns = list(req_columns) + ["is_decoy"]
 
+    # Only request columns the file actually has: quantms.io writers vary by version,
+    # and pyarrow raises rather than ignoring an absent column.
+    available = set(pq.ParquetFile(file_path).schema_arrow.names)
+    missing = [column for column in req_columns if column not in available]
+    if missing:
+        log.debug(f"{qpx_type}.parquet has no {', '.join(missing)}; reading without them.")
+    req_columns = [column for column in req_columns if column in available]
+
     remove_decoy = config.kwargs.get("remove_decoy", False)
-    parquet_filters = [("is_decoy", "==", False)] if remove_decoy else None
+    parquet_filters = (
+        [("is_decoy", "==", False)] if remove_decoy and "is_decoy" in available else None
+    )
 
     df = pd.read_parquet(
         path=file_path,

--- a/pmultiqc/modules/qpx/qpx_io.py
+++ b/pmultiqc/modules/qpx/qpx_io.py
@@ -37,6 +37,28 @@ QPX_COLUMNS = {
 }
 
 
+def select_columns(df, columns, context):
+    """Return ``df[columns]`` only if every column is present, else ``None``.
+
+    Because the reader skips columns a file does not have, a loaded table may
+    legitimately lack one. Selecting a fixed list would raise KeyError, which the
+    module's _safe_draw swallows -- silently dropping a whole section. Callers use
+    this to skip that plot deliberately, with a log line saying why.
+    """
+    if df is None or getattr(df, "empty", True):
+        return None
+
+    missing = [column for column in columns if column not in df.columns]
+    if missing:
+        log.warning(
+            f"[{context}] Skipped: required column(s) not present in the parquet data: "
+            f"{', '.join(missing)}."
+        )
+        return None
+
+    return df[list(columns)].copy()
+
+
 def parse_qpx_parquet(file_path, qpx_type):
 
     req_columns = QPX_COLUMNS[qpx_type]

--- a/pmultiqc/modules/qpx/qpx_io.py
+++ b/pmultiqc/modules/qpx/qpx_io.py
@@ -20,7 +20,9 @@ QPX_COLUMNS = {
         "posterior_error_probability", "is_decoy",
         "calculated_mz", "observed_mz",
         "mass_error_ppm", "run_file_name",
-        "scan", "rt", "protein_accessions"
+        "scan", "rt", "protein_accessions",
+        # Search-engine scores; free-form names, so read and inspected at runtime.
+        "additional_scores"
     ],
     "pg": [
         "pg_accessions", "anchor_protein",
@@ -37,7 +39,11 @@ QPX_COLUMNS = {
         # keying on anchor_protein alone silently loses every multi-accession group.
         # Optional (absent in older writers); skipped automatically when missing.
         "pg_accessions", "modifications", "rt",
-        "calculated_mz", "observed_mz", "unique"
+        "calculated_mz", "observed_mz", "unique",
+        # DIA-NN emits no psm.parquet, so feature.parquet stands in for it: these are
+        # the columns the identification-level plots read.
+        "scan", "posterior_error_probability", "additional_scores",
+        "mass_error_ppm", "missed_cleavages"
     ]
 }
 

--- a/pmultiqc/modules/qpx/qpx_mass_error.py
+++ b/pmultiqc/modules/qpx/qpx_mass_error.py
@@ -1,0 +1,103 @@
+"""Mass-error trends for the QPX module.
+
+quantms.io declares ``mass_error_ppm`` on both psm and feature, but it is optional and
+commonly left null -- it is empty in every test project seen so far. ``calculated_mz``
+and ``observed_mz`` are core fields, though, so the error is derivable:
+
+    ppm = (observed_mz - calculated_mz) / calculated_mz * 1e6
+    Da  = (observed_mz - calculated_mz) * charge
+
+This module prefers the stored column when it carries data and falls back to deriving
+it, reporting which route it took. If neither is possible the section is skipped.
+"""
+
+from __future__ import absolute_import
+
+import numpy as np
+import pandas as pd
+
+from pmultiqc.modules.common.logging import get_logger
+from pmultiqc.modules.common.stats import cal_delta_mass_dict
+from pmultiqc.modules.qpx.qpx_io import has_data
+
+
+log = get_logger("pmultiqc.modules.qpx.qpx_mass_error")
+
+# Beyond this the value is not a calibration error but a mis-assignment; excluded so a
+# handful of outliers cannot flatten the histogram.
+PPM_SANITY_LIMIT = 1000.0
+
+
+def calculate_mass_error(psm_df):
+    """Return ``(ppm_dict, da_dict, source)`` for the mass-error plots.
+
+    Each dict is the binned structure ``draw_delta_mass_da_ppm`` expects, or None when
+    that flavour cannot be produced. ``source`` is "column" or "derived" for logging.
+    """
+    if psm_df is None or getattr(psm_df, "empty", True):
+        return None, None, None
+
+    ppm_series, source = _ppm_series(psm_df)
+    da_series = _da_series(psm_df)
+
+    ppm_dict = _binned(ppm_series, "ppm")
+    da_dict = _binned(da_series, "delta_da")
+
+    if ppm_dict is None and da_dict is None:
+        log.info(
+            "[Mass Error] Skipped: neither 'mass_error_ppm' nor "
+            "'calculated_mz'/'observed_mz' carry usable values."
+        )
+        return None, None, None
+
+    return ppm_dict, da_dict, source
+
+
+def _ppm_series(psm_df):
+    """Prefer the stored ppm column; derive from m/z when it is absent or empty."""
+    if has_data(psm_df, "mass_error_ppm"):
+        series = pd.to_numeric(psm_df["mass_error_ppm"], errors="coerce")
+        log.info("[Mass Error] Using the 'mass_error_ppm' column.")
+        return series, "column"
+
+    if has_data(psm_df, "calculated_mz", "observed_mz"):
+        calculated = pd.to_numeric(psm_df["calculated_mz"], errors="coerce")
+        observed = pd.to_numeric(psm_df["observed_mz"], errors="coerce")
+        series = (observed - calculated) / calculated.replace(0, np.nan) * 1e6
+        log.info(
+            "[Mass Error] 'mass_error_ppm' is empty; deriving ppm from "
+            "observed_mz/calculated_mz."
+        )
+        return series, "derived"
+
+    return None, None
+
+
+def _da_series(psm_df):
+    """Delta mass in Da needs the charge to convert from m/z difference to mass."""
+    if not has_data(psm_df, "calculated_mz", "observed_mz", "charge"):
+        return None
+
+    calculated = pd.to_numeric(psm_df["calculated_mz"], errors="coerce")
+    observed = pd.to_numeric(psm_df["observed_mz"], errors="coerce")
+    charge = pd.to_numeric(psm_df["charge"], errors="coerce")
+
+    return (observed - calculated) * charge
+
+
+def _binned(series, name):
+    if series is None:
+        return None
+
+    series = series.replace([np.inf, -np.inf], np.nan).dropna()
+    if name == "ppm":
+        series = series[series.abs() <= PPM_SANITY_LIMIT]
+    if series.empty:
+        return None
+
+    frame = pd.DataFrame({name: series})
+    # cal_delta_mass_dict bins with pd.value_counts(bins=...), which needs a spread.
+    if frame[name].nunique() < 2:
+        return None
+
+    return cal_delta_mass_dict(frame, name)

--- a/pmultiqc/modules/qpx/qpx_quant.py
+++ b/pmultiqc/modules/qpx/qpx_quant.py
@@ -16,7 +16,7 @@ from multiqc.plots import box
 
 from pmultiqc.modules.common.logging import get_logger
 from pmultiqc.modules.common.plots.general import (
-    trim_box_outliers,
+    summarise_box_data,
     plot_html_check,
     stat_pep_intensity,
 )
@@ -284,7 +284,7 @@ def draw_protein_intensity(sub_section, plot_data):
     else:
         plot_data = [plot_data[0]]
 
-    plot_data, dropped = trim_box_outliers(plot_data)
+    plot_data = summarise_box_data(plot_data)
 
     box_html = plot_html_check(box.plot(plot_data, pconfig=draw_config))
 
@@ -292,11 +292,7 @@ def draw_protein_intensity(sub_section, plot_data):
         sub_section=sub_section,
         plot=box_html,
         order=6,
-        description=(
-            "Protein group intensity per Run."
-            + (f" The most extreme {dropped:,} values are omitted so the boxes stay legible."
-               if dropped else "")
-        ),
+        description="Protein group intensity per Run.",
         helptext="""
             The intensity of each protein group is taken from the `intensity` column of
             pg.parquet and log2-transformed. Zero and missing intensities are ignored.
@@ -455,7 +451,7 @@ def draw_intensity_std(sub_section, box_data):
         "save_data_file": False,
     }
 
-    box_data, dropped = trim_box_outliers(box_data)
+    box_data = summarise_box_data(box_data)
 
     box_html = plot_html_check(box.plot(list_of_data_by_sample=box_data, pconfig=draw_config))
 

--- a/pmultiqc/modules/qpx/qpx_quant.py
+++ b/pmultiqc/modules/qpx/qpx_quant.py
@@ -58,7 +58,7 @@ def create_qpx_protein_table(pg_df, feature_df, sample_df, file_df):
 
     table_dict = {}
     for group_key, group in df.groupby("_group_key"):
-        protein = _display_name(group)
+        protein = _display_name(group, group_key)
         entry = {
             "ProteinName": protein,
             "Average Intensity": float(np.log10(group["intensity"].mean())),
@@ -75,7 +75,7 @@ def create_qpx_protein_table(pg_df, feature_df, sample_df, file_df):
             "description": "Name/Identifier(s) of the protein (group)",
         },
     }
-    if peptides_per_protein:
+    if any("Peptides_Number" in entry for entry in table_dict.values()):
         headers["Peptides_Number"] = {
             "title": "Number of Peptides",
             "description": "Number of distinct peptide sequences per protein",
@@ -144,11 +144,15 @@ def protein_group_key(df):
     return pd.Series([None] * len(df), index=df.index)
 
 
-def _display_name(group):
-    """Human-readable label for a protein group: the anchor when present."""
+def _display_name(group, group_key):
+    """Human-readable label for a protein group: the anchor when present.
+
+    Falls back to the group key (the accession set), never to a positional index --
+    a DataFrame has no .name, so the old fallback labelled proteins "0", "1", "2".
+    """
     if "anchor_protein" in group.columns and group["anchor_protein"].notna().any():
         return str(group["anchor_protein"].dropna().iloc[0])
-    return str(group.name if hasattr(group, "name") else group.index[0])
+    return str(group_key)
 
 
 def _peptides_per_protein(feature_df):
@@ -193,6 +197,17 @@ def _feature_accession_key(cell):
     return ";".join(sorted(set(accessions))) or None
 
 
+def _merge_key(frame, column):
+    """Copy of a frame with the merge key coerced to str.
+
+    'Sample' arrives as int from the parquet-derived design but as str from an OpenMS
+    design file, and pandas refuses to merge int64 against object.
+    """
+    out = frame.copy()
+    out[column] = out[column].astype(str)
+    return out
+
+
 def _add_condition_intensities(table_dict, df, sample_df, file_df):
     """Add a per-condition average intensity column, when a design is available."""
     if sample_df is None or getattr(sample_df, "empty", True):
@@ -206,8 +221,10 @@ def _add_condition_intensities(table_dict, df, sample_df, file_df):
     if not {"Sample", "Run"}.issubset(file_df.columns):
         return []
 
-    run_to_sample = file_df[["Sample", "Run"]].drop_duplicates()
-    sample_to_condition = sample_df[["Sample", "Condition"]].drop_duplicates()
+    run_to_sample = _merge_key(file_df[["Sample", "Run"]].drop_duplicates(), "Sample")
+    sample_to_condition = _merge_key(
+        sample_df[["Sample", "Condition"]].drop_duplicates(), "Sample"
+    )
 
     merged = df.merge(run_to_sample, left_on="run", right_on="Run", how="inner")
     merged = merged.merge(sample_to_condition, on="Sample", how="inner")
@@ -321,8 +338,6 @@ def create_qpx_peptide_table(feature_df, sample_df, file_df):
     if df.empty:
         return None, None
 
-    df["_group_key"] = protein_group_key(df) if "pg_accessions" in df.columns else None
-
     table_dict = {}
     for peptidoform, group in df.groupby("peptidoform"):
         entry = {
@@ -421,8 +436,12 @@ def calculate_intensity_std(feature_df, sample_df, file_df):
         return {}
 
     df = df.merge(
-        file_df[["Sample", "Run"]].drop_duplicates(), left_on="run", right_on="Run", how="inner"
-    ).merge(sample_df[["Sample", "Condition"]].drop_duplicates(), on="Sample", how="inner")
+        _merge_key(file_df[["Sample", "Run"]].drop_duplicates(), "Sample"),
+        left_on="run", right_on="Run", how="inner",
+    ).merge(
+        _merge_key(sample_df[["Sample", "Condition"]].drop_duplicates(), "Sample"),
+        on="Sample", how="inner",
+    )
     if df.empty:
         return {}
 

--- a/pmultiqc/modules/qpx/qpx_quant.py
+++ b/pmultiqc/modules/qpx/qpx_quant.py
@@ -16,6 +16,7 @@ from multiqc.plots import box
 
 from pmultiqc.modules.common.logging import get_logger
 from pmultiqc.modules.common.plots.general import (
+    box_axis_range,
     plot_html_check,
     stat_pep_intensity,
 )
@@ -283,6 +284,10 @@ def draw_protein_intensity(sub_section, plot_data):
     else:
         plot_data = [plot_data[0]]
 
+    x_range = box_axis_range(plot_data)
+    if x_range:
+        draw_config["xmin"], draw_config["xmax"] = x_range
+
     box_html = plot_html_check(box.plot(plot_data, pconfig=draw_config))
 
     add_sub_section(
@@ -447,6 +452,10 @@ def draw_intensity_std(sub_section, box_data):
         "xlab": "Standard Deviation of log2(Intensity)",
         "save_data_file": False,
     }
+
+    x_range = box_axis_range(box_data)
+    if x_range:
+        draw_config["xmin"], draw_config["xmax"] = x_range
 
     box_html = plot_html_check(box.plot(list_of_data_by_sample=box_data, pconfig=draw_config))
 

--- a/pmultiqc/modules/qpx/qpx_quant.py
+++ b/pmultiqc/modules/qpx/qpx_quant.py
@@ -1,0 +1,226 @@
+"""Protein-level quantification for the QPX module.
+
+``pg.parquet`` carries an intensity and a q-value per (protein group, run), but the
+QPX module previously drew nothing from it -- its Quantification Analysis section held
+only the peptide intensity box. This module turns that table into the same Protein
+Quantification Table the DIA-NN and mzIdentML reports draw, plus a protein intensity
+distribution matching the peptide one.
+"""
+
+from __future__ import absolute_import
+
+import numpy as np
+import pandas as pd
+
+from multiqc.plots import box
+
+from pmultiqc.modules.common.logging import get_logger
+from pmultiqc.modules.common.plots.general import (
+    plot_html_check,
+    stat_pep_intensity,
+)
+from pmultiqc.modules.core.section_groups import add_sub_section
+
+
+log = get_logger("pmultiqc.modules.qpx.qpx_quant")
+
+# Matches the row cap used by the DIA-NN/mzIdentML protein tables.
+MAX_TABLE_ROWS = 50
+
+
+def create_qpx_protein_table(pg_df, feature_df, sample_df, file_df):
+    """Build ``(table_dict, headers)`` for :func:`draw_protein_table`.
+
+    Returns ``(None, None)`` when pg.parquet cannot supply protein quantification.
+    """
+    if pg_df is None or getattr(pg_df, "empty", True):
+        return None, None
+    if "anchor_protein" not in pg_df.columns or "intensity" not in pg_df.columns:
+        log.debug("pg.parquet lacks anchor_protein/intensity; no protein table.")
+        return None, None
+
+    df = pg_df.copy()
+    df["intensity"] = pd.to_numeric(df["intensity"], errors="coerce")
+    df = df[df["intensity"] > 0].dropna(subset=["anchor_protein"])
+    if df.empty:
+        log.debug("pg.parquet has no positive intensities; no protein table.")
+        return None, None
+
+    peptides_per_protein = _peptides_per_protein(feature_df)
+
+    table_dict = {}
+    for protein, group in df.groupby("anchor_protein"):
+        protein = str(protein)
+        entry = {
+            "ProteinName": protein,
+            "Average Intensity": float(np.log10(group["intensity"].mean())),
+        }
+        if protein in peptides_per_protein:
+            entry["Peptides_Number"] = int(peptides_per_protein[protein])
+        if "global_qvalue" in group.columns and group["global_qvalue"].notna().any():
+            entry["Global Q-value"] = float(group["global_qvalue"].min())
+        table_dict[protein] = entry
+
+    headers = {
+        "ProteinName": {
+            "title": "Protein Name",
+            "description": "Name/Identifier(s) of the protein (group)",
+        },
+    }
+    if peptides_per_protein:
+        headers["Peptides_Number"] = {
+            "title": "Number of Peptides",
+            "description": "Number of distinct peptide sequences per protein",
+            "format": "{:,.0f}",
+        }
+    headers["Average Intensity"] = {
+        "title": "Average Intensity",
+        "description": "log10 of the average protein group intensity across runs",
+        "format": "{:,.4f}",
+    }
+    if any("Global Q-value" in entry for entry in table_dict.values()):
+        headers["Global Q-value"] = {
+            "title": "Global Q-value",
+            "description": "Best (lowest) global q-value reported for the protein group",
+            "format": "{:,.2e}",
+        }
+
+    condition_columns = _add_condition_intensities(table_dict, df, sample_df, file_df)
+    for condition in condition_columns:
+        headers[condition] = {
+            "title": condition,
+            "description": f"log10 average protein intensity in condition '{condition}'",
+            "format": "{:,.4f}",
+        }
+
+    # Sort by intensity so the capped table shows the most abundant proteins.
+    ordered = sorted(
+        table_dict.values(), key=lambda e: e.get("Average Intensity", 0), reverse=True
+    )
+    result_dict = {i: entry for i, entry in enumerate(ordered, start=1)}
+
+    log.info(
+        f"[Quantification] Protein quantification table: {len(table_dict)} protein group(s)"
+        f"{f', showing top {MAX_TABLE_ROWS}' if len(table_dict) > MAX_TABLE_ROWS else ''}."
+    )
+    return result_dict, headers
+
+
+def _peptides_per_protein(feature_df):
+    """Count distinct peptide sequences per anchor protein, if features are available."""
+    if feature_df is None or getattr(feature_df, "empty", True):
+        return {}
+    if "anchor_protein" not in feature_df.columns or "sequence" not in feature_df.columns:
+        return {}
+
+    counts = (
+        feature_df.dropna(subset=["anchor_protein", "sequence"])
+        .groupby("anchor_protein")["sequence"]
+        .nunique()
+    )
+    return {str(k): v for k, v in counts.items()}
+
+
+def _add_condition_intensities(table_dict, df, sample_df, file_df):
+    """Add a per-condition average intensity column, when a design is available."""
+    if sample_df is None or getattr(sample_df, "empty", True):
+        return []
+    if file_df is None or getattr(file_df, "empty", True):
+        return []
+    if "run" not in df.columns:
+        return []
+    if not {"Sample", "Condition"}.issubset(sample_df.columns):
+        return []
+    if not {"Sample", "Run"}.issubset(file_df.columns):
+        return []
+
+    run_to_sample = file_df[["Sample", "Run"]].drop_duplicates()
+    sample_to_condition = sample_df[["Sample", "Condition"]].drop_duplicates()
+
+    merged = df.merge(run_to_sample, left_on="run", right_on="Run", how="inner")
+    merged = merged.merge(sample_to_condition, on="Sample", how="inner")
+    if merged.empty:
+        return []
+
+    conditions = []
+    for condition, condition_group in merged.groupby("Condition"):
+        condition = str(condition)
+        conditions.append(condition)
+        for protein, group in condition_group.groupby("anchor_protein"):
+            entry = table_dict.get(str(protein))
+            if entry is not None:
+                entry[condition] = float(np.log10(group["intensity"].mean()))
+
+    return conditions
+
+
+def get_protein_intensity(pg_df, sdrf_file_df):
+    """Protein group intensity distributions as ``[by_run, by_sample]``.
+
+    Mirrors :func:`get_pep_intensity` so the protein plot matches the peptide one.
+    """
+    by_run = {}
+    by_sample = {}
+
+    if pg_df is None or getattr(pg_df, "empty", True):
+        return [by_run, by_sample]
+    if "run" not in pg_df.columns or "intensity" not in pg_df.columns:
+        return [by_run, by_sample]
+
+    df = pg_df[["run", "intensity"]].copy()
+    df["intensity"] = pd.to_numeric(df["intensity"], errors="coerce")
+    df = df[df["intensity"] > 0]
+    if df.empty:
+        return [by_run, by_sample]
+
+    for run, group in df.groupby("run"):
+        by_run[str(run)] = stat_pep_intensity(group["intensity"])
+
+    if sdrf_file_df is not None and not getattr(sdrf_file_df, "empty", True):
+        if {"Sample", "Run"}.issubset(sdrf_file_df.columns):
+            merged = df.merge(
+                right=sdrf_file_df[["Sample", "Run"]].drop_duplicates(),
+                left_on="run",
+                right_on="Run",
+                how="left",
+            ).dropna(subset=["Sample"])
+
+            for sample, group in merged.groupby("Sample", sort=True):
+                by_sample[f"Sample {str(sample)}"] = stat_pep_intensity(group["intensity"])
+
+    return [by_run, by_sample]
+
+
+def draw_protein_intensity(sub_section, plot_data):
+    """Box plot of protein group intensity, by run and (when known) by sample."""
+    if not plot_data or not plot_data[0]:
+        return
+
+    draw_config = {
+        "id": "protein_intensity_distribution_box",
+        "cpswitch": False,
+        "cpswitch_c_active": False,
+        "title": "Protein Intensity Distribution",
+        "tt_decimals": 2,
+        "xlab": "log2(Intensity)",
+        "sort_samples": False,
+        "save_data_file": False,
+    }
+
+    if len(plot_data) > 1 and plot_data[1]:
+        draw_config["data_labels"] = ["by Run", "by Sample"]
+    else:
+        plot_data = [plot_data[0]]
+
+    box_html = plot_html_check(box.plot(plot_data, pconfig=draw_config))
+
+    add_sub_section(
+        sub_section=sub_section,
+        plot=box_html,
+        order=6,
+        description="Protein group intensity per Run.",
+        helptext="""
+            The intensity of each protein group is taken from the `intensity` column of
+            pg.parquet and log2-transformed. Zero and missing intensities are ignored.
+            """,
+    )

--- a/pmultiqc/modules/qpx/qpx_quant.py
+++ b/pmultiqc/modules/qpx/qpx_quant.py
@@ -295,3 +295,169 @@ def draw_protein_intensity(sub_section, plot_data):
             pg.parquet and log2-transformed. Zero and missing intensities are ignored.
             """,
     )
+
+
+def create_qpx_peptide_table(feature_df, sample_df, file_df):
+    """Peptide-level quantification table, mirroring the protein one.
+
+    Returns ``(table_dict, headers)`` or ``(None, None)``.
+    """
+    from pmultiqc.modules.qpx.qpx_io import has_data
+
+    if not has_data(feature_df, "peptidoform", "intensities"):
+        log.debug("feature.parquet lacks peptidoform/intensities; no peptide table.")
+        return None, None
+
+    df = feature_df.dropna(subset=["intensities"]).explode("intensities")
+    df = df.dropna(subset=["intensities"])
+    if df.empty:
+        return None, None
+
+    df["intensity"] = pd.to_numeric(df["intensities"].str.get("intensity"), errors="coerce")
+    df = df[df["intensity"] > 0]
+    if df.empty:
+        return None, None
+
+    df["_group_key"] = protein_group_key(df) if "pg_accessions" in df.columns else None
+
+    table_dict = {}
+    for peptidoform, group in df.groupby("peptidoform"):
+        entry = {
+            "PeptideID": str(peptidoform),
+            "Average Intensity": float(np.log10(group["intensity"].mean())),
+        }
+        if "anchor_protein" in group.columns and group["anchor_protein"].notna().any():
+            entry["ProteinName"] = str(group["anchor_protein"].dropna().iloc[0])
+        if "charge" in group.columns and group["charge"].notna().any():
+            entry["Charge"] = int(group["charge"].dropna().iloc[0])
+        table_dict[str(peptidoform)] = entry
+
+    headers = {"PeptideID": {"title": "Peptidoform", "description": "Peptide sequence with modifications"}}
+    if any("ProteinName" in e for e in table_dict.values()):
+        headers["ProteinName"] = {"title": "Protein Name", "description": "Anchor protein of the group"}
+    if any("Charge" in e for e in table_dict.values()):
+        headers["Charge"] = {"title": "Charge", "description": "Precursor charge", "format": "{:,.0f}"}
+    headers["Average Intensity"] = {
+        "title": "Average Intensity",
+        "description": "log10 of the average peptide intensity across runs",
+        "format": "{:,.4f}",
+    }
+
+    ordered = sorted(table_dict.values(), key=lambda e: e.get("Average Intensity", 0), reverse=True)
+    result = {i: entry for i, entry in enumerate(ordered, start=1)}
+    log.info(f"[Quantification] Peptide quantification table: {len(table_dict)} peptidoform(s).")
+    return result, headers
+
+
+def protein_intensity_pca(pg_df):
+    """PCA of the protein-group x run intensity matrix. None if not computable."""
+    try:
+        from sklearn.decomposition import PCA
+        from sklearn.preprocessing import StandardScaler
+    except ImportError:
+        log.debug("[Quantification] scikit-learn unavailable; skipping PCA.")
+        return None
+
+    from pmultiqc.modules.qpx.qpx_io import has_data
+
+    if not has_data(pg_df, "run", "intensity"):
+        return None
+
+    df = pg_df.copy()
+    df["intensity"] = pd.to_numeric(df["intensity"], errors="coerce")
+    df["_group_key"] = protein_group_key(df)
+    df = df.dropna(subset=["intensity", "_group_key"])
+    df = df[df["intensity"] > 0]
+    if df.empty:
+        return None
+
+    matrix = df.pivot_table(
+        index="_group_key", columns="run", values="intensity", aggfunc="mean"
+    )
+    # PCA needs at least two runs, and rows complete across them.
+    matrix = matrix.dropna()
+    if matrix.shape[1] < 2 or matrix.shape[0] < 2:
+        log.info(
+            "[Quantification] PCA skipped: needs >=2 runs and >=2 proteins quantified in "
+            f"all of them (got {matrix.shape[0]} x {matrix.shape[1]})."
+        )
+        return None
+
+    scaled = StandardScaler().fit_transform(np.log2(matrix).T)
+    result = PCA(n_components=2).fit_transform(scaled)
+
+    log.info(
+        f"[Quantification] PCA over {matrix.shape[0]} protein groups x {matrix.shape[1]} runs."
+    )
+    return {
+        str(run): {"x": float(result[i, 0]), "y": float(result[i, 1])}
+        for i, run in enumerate(matrix.columns)
+    }
+
+
+def calculate_intensity_std(feature_df, sample_df, file_df):
+    """Per-condition standard deviation of log2 peptide intensity."""
+    from pmultiqc.modules.qpx.qpx_io import has_data
+
+    if not has_data(feature_df, "peptidoform", "intensities", "run"):
+        return {}
+    if sample_df is None or getattr(sample_df, "empty", True):
+        return {}
+    if file_df is None or getattr(file_df, "empty", True):
+        return {}
+    if not {"Sample", "Condition"}.issubset(sample_df.columns):
+        return {}
+    if not {"Sample", "Run"}.issubset(file_df.columns):
+        return {}
+
+    df = feature_df[["run", "peptidoform", "intensities"]].dropna(subset=["intensities"])
+    df = df.explode("intensities").dropna(subset=["intensities"])
+    df["intensity"] = pd.to_numeric(df["intensities"].str.get("intensity"), errors="coerce")
+    df = df[df["intensity"] > 0]
+    if df.empty:
+        return {}
+
+    df = df.merge(
+        file_df[["Sample", "Run"]].drop_duplicates(), left_on="run", right_on="Run", how="inner"
+    ).merge(sample_df[["Sample", "Condition"]].drop_duplicates(), on="Sample", how="inner")
+    if df.empty:
+        return {}
+
+    df["log2_intensity"] = np.log2(df["intensity"])
+
+    result = {}
+    for condition, group in df.groupby("Condition"):
+        stds = group.groupby("peptidoform")["log2_intensity"].std().dropna()
+        if not stds.empty:
+            result[str(condition)] = stds.tolist()
+
+    return result
+
+
+def draw_intensity_std(sub_section, box_data):
+    """Box plot of per-condition standard deviation of log2 peptide intensity."""
+    if not box_data:
+        return
+
+    draw_config = {
+        "id": "qpx_std_intensity_box",
+        "title": "Standard Deviation of Intensity",
+        "cpswitch": False,
+        "tt_decimals": 5,
+        "xlab": "Standard Deviation of log2(Intensity)",
+        "save_data_file": False,
+    }
+
+    box_html = plot_html_check(box.plot(list_of_data_by_sample=box_data, pconfig=draw_config))
+
+    add_sub_section(
+        sub_section=sub_section,
+        plot=box_html,
+        order=8,
+        description="Spread of each peptide's log2 intensity within a condition.",
+        helptext="""
+            For every peptidoform the standard deviation of its log2 intensity is computed
+            across the runs of one condition; the box shows the distribution of those values.
+            A tight distribution indicates reproducible quantification within the condition.
+            """,
+    )

--- a/pmultiqc/modules/qpx/qpx_quant.py
+++ b/pmultiqc/modules/qpx/qpx_quant.py
@@ -35,13 +35,20 @@ def create_qpx_protein_table(pg_df, feature_df, sample_df, file_df):
     """
     if pg_df is None or getattr(pg_df, "empty", True):
         return None, None
-    if "anchor_protein" not in pg_df.columns or "intensity" not in pg_df.columns:
-        log.debug("pg.parquet lacks anchor_protein/intensity; no protein table.")
+    if "intensity" not in pg_df.columns:
+        log.debug("pg.parquet lacks intensity; no protein table.")
         return None, None
 
     df = pg_df.copy()
     df["intensity"] = pd.to_numeric(df["intensity"], errors="coerce")
-    df = df[df["intensity"] > 0].dropna(subset=["anchor_protein"])
+    df = df[df["intensity"] > 0]
+
+    # The spec is explicit that anchor_protein is a display label only and must not key
+    # per-protein statistics -- protein groups are not guaranteed disjoint, so several
+    # groups can share an anchor. Group on the full accession set instead and keep
+    # anchor_protein purely for the displayed name.
+    df["_group_key"] = protein_group_key(df)
+    df = df.dropna(subset=["_group_key"])
     if df.empty:
         log.debug("pg.parquet has no positive intensities; no protein table.")
         return None, None
@@ -49,17 +56,17 @@ def create_qpx_protein_table(pg_df, feature_df, sample_df, file_df):
     peptides_per_protein = _peptides_per_protein(feature_df)
 
     table_dict = {}
-    for protein, group in df.groupby("anchor_protein"):
-        protein = str(protein)
+    for group_key, group in df.groupby("_group_key"):
+        protein = _display_name(group)
         entry = {
             "ProteinName": protein,
             "Average Intensity": float(np.log10(group["intensity"].mean())),
         }
-        if protein in peptides_per_protein:
-            entry["Peptides_Number"] = int(peptides_per_protein[protein])
+        if group_key in peptides_per_protein:
+            entry["Peptides_Number"] = int(peptides_per_protein[group_key])
         if "global_qvalue" in group.columns and group["global_qvalue"].notna().any():
             entry["Global Q-value"] = float(group["global_qvalue"].min())
-        table_dict[protein] = entry
+        table_dict[group_key] = entry
 
     headers = {
         "ProteinName": {
@@ -106,19 +113,83 @@ def create_qpx_protein_table(pg_df, feature_df, sample_df, file_df):
     return result_dict, headers
 
 
+def _accession_key(cell):
+    """Stable key for a list<string> accession set, or None when unusable."""
+    if cell is None:
+        return None
+    if isinstance(cell, str):
+        return cell or None
+    try:
+        parts = sorted({str(a) for a in cell if a is not None and str(a) != ""})
+    except TypeError:
+        text = str(cell)
+        return text or None
+    return ";".join(parts) or None
+
+
+def protein_group_key(df):
+    """Key protein groups by their accession set, never by anchor_protein.
+
+    Protein groups are not guaranteed disjoint and anchor_protein is documented as a
+    display label, so two distinct groups can share one anchor. pg_accessions is the
+    identifying set; anchor_protein is only a fallback when it is unavailable.
+    """
+    if "pg_accessions" in df.columns:
+        keys = df["pg_accessions"].apply(_accession_key)
+        if keys.notna().any():
+            return keys
+    if "anchor_protein" in df.columns:
+        return df["anchor_protein"].astype(str).where(df["anchor_protein"].notna())
+    return pd.Series([None] * len(df), index=df.index)
+
+
+def _display_name(group):
+    """Human-readable label for a protein group: the anchor when present."""
+    if "anchor_protein" in group.columns and group["anchor_protein"].notna().any():
+        return str(group["anchor_protein"].dropna().iloc[0])
+    return str(group.name if hasattr(group, "name") else group.index[0])
+
+
 def _peptides_per_protein(feature_df):
-    """Count distinct peptide sequences per anchor protein, if features are available."""
+    """Count distinct peptide sequences per protein group, keyed like the pg table."""
     if feature_df is None or getattr(feature_df, "empty", True):
         return {}
-    if "anchor_protein" not in feature_df.columns or "sequence" not in feature_df.columns:
+    if "sequence" not in feature_df.columns:
         return {}
 
-    counts = (
-        feature_df.dropna(subset=["anchor_protein", "sequence"])
-        .groupby("anchor_protein")["sequence"]
-        .nunique()
-    )
+    df = feature_df.copy()
+    # feature.pg_accessions is a list<struct> (accession/start/end); reduce to accessions.
+    if "pg_accessions" in df.columns:
+        df["_group_key"] = df["pg_accessions"].apply(_feature_accession_key)
+    elif "anchor_protein" in df.columns:
+        df["_group_key"] = df["anchor_protein"].astype(str)
+    else:
+        return {}
+
+    df = df.dropna(subset=["_group_key", "sequence"])
+    if df.empty:
+        return {}
+
+    counts = df.groupby("_group_key")["sequence"].nunique()
     return {str(k): v for k, v in counts.items()}
+
+
+def _feature_accession_key(cell):
+    """feature.pg_accessions holds structs; pull out the accession strings."""
+    if cell is None:
+        return None
+    try:
+        accessions = []
+        for entry in cell:
+            if isinstance(entry, dict):
+                value = entry.get("accession")
+            else:
+                value = entry
+            if value is not None and str(value) != "":
+                accessions.append(str(value))
+    except TypeError:
+        return _accession_key(cell)
+    return ";".join(sorted(set(accessions))) or None
 
 
 def _add_condition_intensities(table_dict, df, sample_df, file_df):
@@ -146,8 +217,8 @@ def _add_condition_intensities(table_dict, df, sample_df, file_df):
     for condition, condition_group in merged.groupby("Condition"):
         condition = str(condition)
         conditions.append(condition)
-        for protein, group in condition_group.groupby("anchor_protein"):
-            entry = table_dict.get(str(protein))
+        for group_key, group in condition_group.groupby("_group_key"):
+            entry = table_dict.get(group_key)
             if entry is not None:
                 entry[condition] = float(np.log10(group["intensity"].mean()))
 

--- a/pmultiqc/modules/qpx/qpx_quant.py
+++ b/pmultiqc/modules/qpx/qpx_quant.py
@@ -16,7 +16,7 @@ from multiqc.plots import box
 
 from pmultiqc.modules.common.logging import get_logger
 from pmultiqc.modules.common.plots.general import (
-    box_axis_range,
+    trim_box_outliers,
     plot_html_check,
     stat_pep_intensity,
 )
@@ -284,9 +284,7 @@ def draw_protein_intensity(sub_section, plot_data):
     else:
         plot_data = [plot_data[0]]
 
-    x_range = box_axis_range(plot_data)
-    if x_range:
-        draw_config["xmin"], draw_config["xmax"] = x_range
+    plot_data, dropped = trim_box_outliers(plot_data)
 
     box_html = plot_html_check(box.plot(plot_data, pconfig=draw_config))
 
@@ -294,7 +292,11 @@ def draw_protein_intensity(sub_section, plot_data):
         sub_section=sub_section,
         plot=box_html,
         order=6,
-        description="Protein group intensity per Run.",
+        description=(
+            "Protein group intensity per Run."
+            + (f" The most extreme {dropped:,} values are omitted so the boxes stay legible."
+               if dropped else "")
+        ),
         helptext="""
             The intensity of each protein group is taken from the `intensity` column of
             pg.parquet and log2-transformed. Zero and missing intensities are ignored.
@@ -453,9 +455,7 @@ def draw_intensity_std(sub_section, box_data):
         "save_data_file": False,
     }
 
-    x_range = box_axis_range(box_data)
-    if x_range:
-        draw_config["xmin"], draw_config["xmax"] = x_range
+    box_data, dropped = trim_box_outliers(box_data)
 
     box_html = plot_html_check(box.plot(list_of_data_by_sample=box_data, pconfig=draw_config))
 

--- a/pmultiqc/modules/qpx/qpx_sections.py
+++ b/pmultiqc/modules/qpx/qpx_sections.py
@@ -164,9 +164,20 @@ def resolve_contaminant_flags(df, affix):
     if "contaminant" in df.columns and df["contaminant"].notna().any():
         flags = df["contaminant"].fillna(False).astype(bool)
 
-    affix_flags = _affix_flags(df, affix)
-    if affix_flags is not None:
-        flags = affix_flags if flags is None else (flags | affix_flags)
+    # Only supplement with the affix when the producer flagged nothing at all. Where it
+    # did flag rows the column is authoritative and must not be overridden -- but an
+    # all-False column is indistinguishable from "this converter does not set it", and
+    # the OpenMS-consensus heuristic demonstrably misses the "Cont_" prefix these
+    # projects use.
+    if flags is None or not bool(flags.any()):
+        affix_flags = _affix_flags(df, affix)
+        if affix_flags is not None and bool(affix_flags.any()):
+            if flags is not None:
+                log.info(
+                    "[Contaminants] The 'contaminant' flag marks no rows, but "
+                    f"accessions match '{affix}'; using the accession match."
+                )
+            flags = affix_flags
 
     return flags
 
@@ -421,5 +432,45 @@ def draw_qpx_search_engine_scores(sub_section, plot_data, score_name):
             <code>{score_name}</code>. Bin edges span the observed 1st-99th percentile
             range rather than a fixed scale, because score ranges differ by orders of
             magnitude between engines and between q-values, PEPs and raw scores.
+            """,
+    )
+
+
+def draw_qpx_pca(sub_section, pca_data):
+    """PCA scatter of the protein-group intensity matrix.
+
+    A dedicated drawer rather than maxquant_plots.draw_pg_pca, whose helptext describes
+    proteinGroups.txt columns that do not exist in a QPX project.
+    """
+    from multiqc.plots import scatter
+
+    from pmultiqc.modules.common.plots.general import plot_html_check
+    from pmultiqc.modules.core.section_groups import add_sub_section
+
+    if not pca_data:
+        return
+
+    draw_config = {
+        "id": "pca_of_raw_intensity",
+        "cpswitch": False,
+        "cpswitch_c_active": False,
+        "title": "PCA of Protein Intensity",
+        "xlab": "PC #1",
+        "ylab": "PC #2",
+        "save_data_file": False,
+    }
+
+    scatter_html = plot_html_check(scatter.plot(data=pca_data, pconfig=draw_config))
+
+    add_sub_section(
+        sub_section=sub_section,
+        plot=scatter_html,
+        order=4,
+        description="Principal components of the protein group intensity matrix.",
+        helptext="""
+            Protein group intensities from pg.parquet are arranged as a protein x run
+            matrix, restricted to groups quantified in every run, log2-transformed and
+            standardised before PCA. Runs of the same condition are expected to cluster;
+            a run sitting apart from its group is a candidate outlier.
             """,
     )

--- a/pmultiqc/modules/qpx/qpx_sections.py
+++ b/pmultiqc/modules/qpx/qpx_sections.py
@@ -151,22 +151,32 @@ def calculate_contaminants(pg_df, contaminant_affix):
     return per_run, top_n
 
 
+def resolve_contaminant_flags(df, affix):
+    """Boolean contaminant mask, or None when it cannot be determined.
+
+    Shared by the Contaminants section and the heatmap metric so they can never
+    disagree. Unions the producer's flag with a case-insensitive accession match: the
+    flag is authoritative when set, but the OpenMS-consensus heuristic misses the
+    "Cont_" prefix these projects use and reports False for genuine contaminants.
+    """
+    flags = None
+
+    if "contaminant" in df.columns and df["contaminant"].notna().any():
+        flags = df["contaminant"].fillna(False).astype(bool)
+
+    affix_flags = _affix_flags(df, affix)
+    if affix_flags is not None:
+        flags = affix_flags if flags is None else (flags | affix_flags)
+
+    return flags
+
+
 def _contaminant_labels(df, affix):
     """Label each row 'CONTAMINANT:<name>' or 'NOT_CONTAMINANT'; None if undeterminable."""
     names = _protein_names(df)
 
-    if "contaminant" in df.columns and df["contaminant"].notna().any():
-        flags = df["contaminant"].fillna(False).astype(bool)
-    elif affix:
-        if "pg_accessions" in df.columns:
-            flags = df["pg_accessions"].apply(
-                lambda cell: _cell_contains(cell, affix)
-            )
-        elif "anchor_protein" in df.columns:
-            flags = df["anchor_protein"].astype(str).str.contains(affix, regex=False)
-        else:
-            return None
-    else:
+    flags = resolve_contaminant_flags(df, affix)
+    if flags is None:
         return None
 
     return pd.Series(
@@ -181,13 +191,26 @@ def _protein_names(df):
     return protein_group_key(df).astype(str)
 
 
+def _affix_flags(df, affix):
+    """Case-insensitive affix match over accessions, or None when not possible."""
+    if not affix:
+        return None
+    if "pg_accessions" in df.columns:
+        return df["pg_accessions"].apply(lambda cell: _cell_contains(cell, affix))
+    if "anchor_protein" in df.columns:
+        return df["anchor_protein"].astype(str).str.contains(affix, case=False, regex=False)
+    return None
+
+
 def _cell_contains(cell, affix):
+    """Case-insensitive: accession prefixes vary in case (CON__, Cont_, contaminant_)."""
     if cell is None:
         return False
+    needle = affix.lower()
     try:
-        return any(affix in str(a) for a in cell)
+        return any(needle in str(a).lower() for a in cell)
     except TypeError:
-        return affix in str(cell)
+        return needle in str(cell).lower()
 
 
 def _top_n_contaminants(df):
@@ -220,7 +243,18 @@ def _top_n_contaminants(df):
             run_data["Other"] = float(other / total * 100)
         result[str(run)] = run_data
 
-    return result or None
+    if not result:
+        return None
+
+    # draw_top_n_contaminants expects {"plot_data": ..., "cats": ...}, not a flat dict.
+    categories = [name.replace(CONTAMINANT_MARKER, "") for name in top]
+    if any("Other" in run_data for run_data in result.values()):
+        categories.append("Other")
+
+    return {
+        "plot_data": result,
+        "cats": {name: {"name": name} for name in categories},
+    }
 
 
 # ------------------------------------------------------------- search engine scores

--- a/pmultiqc/modules/qpx/qpx_sections.py
+++ b/pmultiqc/modules/qpx/qpx_sections.py
@@ -1,0 +1,391 @@
+"""Identification, contaminant and search-engine sections for the QPX module.
+
+Each builder returns None (or an empty structure) when the QPX fields it needs are
+absent or entirely null, so a section appears only for producers that actually supply
+its data. See :func:`pmultiqc.modules.qpx.qpx_io.has_data` for why presence alone is
+not enough.
+"""
+
+from __future__ import absolute_import
+
+from collections import OrderedDict
+
+import pandas as pd
+
+from pmultiqc.modules.common.common_utils import cal_contaminant_percent
+from pmultiqc.modules.common.histogram import Histogram
+from pmultiqc.modules.common.logging import get_logger
+from pmultiqc.modules.qpx.qpx_io import has_data
+from pmultiqc.modules.qpx.qpx_quant import protein_group_key
+
+
+log = get_logger("pmultiqc.modules.qpx.qpx_sections")
+
+TOP_N_CONTAMINANTS = 5
+
+# Sentinels for the contaminant label column. cal_contaminant_percent flags rows by
+# substring, so the "clean" sentinel must not contain the contaminant marker -- naming
+# them CONTAMINANT / NOT_CONTAMINANT would match every row and report 100%.
+CONTAMINANT_MARKER = "__CONTAM__"
+CLEAN_LABEL = "clean"
+
+
+# ---------------------------------------------------------------- peptides per protein
+
+def build_peptides_per_protein(feature_df, peptides_per_group):
+    """Histogram of distinct peptides per protein group, as draw_num_pep_per_protein wants."""
+    if not peptides_per_group:
+        log.debug("[Identification] No peptides-per-protein counts available.")
+        return None
+
+    pep_plot = Histogram("number of peptides per proteins", plot_category="frequency")
+    for count in peptides_per_group.values():
+        pep_plot.add_value(int(count))
+
+    categories = OrderedDict()
+    categories["Frequency"] = {
+        "name": "Frequency",
+        "description": "number of peptides per proteins",
+    }
+    pep_plot.to_dict(percentage=True, cats=categories)
+
+    return pep_plot
+
+
+# ------------------------------------------------------------------------ oversampling
+
+def calculate_oversampling(id_df):
+    """MS/MS counts per 3D-peak: how often each precursor was identified per run.
+
+    Returns ``(plot_data, cats)`` or ``(None, None)``. A precursor is a
+    (peptidoform, charge) pair, matching the definition the other plugins use.
+    """
+    if not has_data(id_df, "run", "peptidoform", "charge"):
+        log.debug("[MS2] Oversampling needs run/peptidoform/charge; skipping.")
+        return None, None
+
+    df = id_df[["run", "peptidoform", "charge"]].dropna(subset=["peptidoform", "charge"])
+    if df.empty:
+        return None, None
+
+    plot_data = {}
+    seen_bins = set()
+    for run, group in df.groupby("run"):
+        counts = group.groupby(["peptidoform", "charge"]).size()
+        if counts.empty:
+            continue
+        # Bin as 1, 2, >=3, the convention used by the MaxQuant/FragPipe plots.
+        binned = counts.clip(upper=3).value_counts()
+        total = binned.sum()
+        if total <= 0:
+            continue
+        run_data = {}
+        for value, count in binned.items():
+            label = ">=3" if value >= 3 else str(int(value))
+            run_data[label] = float(count / total * 100)
+            seen_bins.add(label)
+        plot_data[str(run)] = run_data
+
+    if not plot_data:
+        return None, None
+
+    cats = OrderedDict()
+    for label in ["1", "2", ">=3"]:
+        if label in seen_bins:
+            cats[label] = {"name": label}
+
+    return plot_data, cats
+
+
+# ------------------------------------------------------------------------ contaminants
+
+def calculate_contaminants(pg_df, contaminant_affix):
+    """Per-run contaminant intensity share, plus the top-N contaminant breakdown.
+
+    Returns ``(per_run_percent, top_n_data)``; either may be None. Distinguishes an
+    all-null 'contaminant' flag (unknown -> skip) from an all-False one (known clean).
+    """
+    if pg_df is None or getattr(pg_df, "empty", True):
+        return None, None
+    if not has_data(pg_df, "run", "intensity"):
+        log.debug("[Contaminants] Needs run/intensity in pg.parquet; skipping.")
+        return None, None
+
+    df = pg_df.copy()
+    df["intensity"] = pd.to_numeric(df["intensity"], errors="coerce")
+    df = df.dropna(subset=["intensity"])
+    if df.empty:
+        return None, None
+
+    labels = _contaminant_labels(df, contaminant_affix)
+    if labels is None:
+        log.info(
+            "[Contaminants] Skipped: the 'contaminant' flag is entirely null for this "
+            "producer and no accession column is available to match the affix."
+        )
+        return None, None
+
+    df["_contaminant"] = labels
+
+    per_run = cal_contaminant_percent(
+        df=df.assign(_protein=df["_contaminant"]),
+        protein_col="_protein",
+        intensity_col="intensity",
+        run_col="run",
+        contam_affix=CONTAMINANT_MARKER,
+    )
+
+    # An all-zero series means the producer flagged no contaminants at all. That is a
+    # real answer, but a bar chart of zeros shows nothing (and MultiQC rejects it), so
+    # report it in the log and skip the section.
+    if per_run and not any(
+        v.get("Potential Contaminants", 0) > 0 for v in per_run.values()
+    ):
+        log.info(
+            "[Contaminants] No contaminant signal in any run (0% throughout); "
+            "skipping the contaminants section."
+        )
+        return None, None
+
+    top_n = _top_n_contaminants(df)
+    return per_run, top_n
+
+
+def _contaminant_labels(df, affix):
+    """Label each row 'CONTAMINANT:<name>' or 'NOT_CONTAMINANT'; None if undeterminable."""
+    names = _protein_names(df)
+
+    if "contaminant" in df.columns and df["contaminant"].notna().any():
+        flags = df["contaminant"].fillna(False).astype(bool)
+    elif affix:
+        if "pg_accessions" in df.columns:
+            flags = df["pg_accessions"].apply(
+                lambda cell: _cell_contains(cell, affix)
+            )
+        elif "anchor_protein" in df.columns:
+            flags = df["anchor_protein"].astype(str).str.contains(affix, regex=False)
+        else:
+            return None
+    else:
+        return None
+
+    return pd.Series(
+        [CONTAMINANT_MARKER + n if f else CLEAN_LABEL for n, f in zip(names, flags)],
+        index=df.index,
+    )
+
+
+def _protein_names(df):
+    if "anchor_protein" in df.columns:
+        return df["anchor_protein"].astype(str).fillna("unknown")
+    return protein_group_key(df).astype(str)
+
+
+def _cell_contains(cell, affix):
+    if cell is None:
+        return False
+    try:
+        return any(affix in str(a) for a in cell)
+    except TypeError:
+        return affix in str(cell)
+
+
+def _top_n_contaminants(df):
+    """Per-run intensity share of the N most abundant contaminants."""
+    contaminated = df[df["_contaminant"] != CLEAN_LABEL]
+    if contaminated.empty:
+        return None
+
+    totals = df.groupby("run")["intensity"].sum()
+    ranked = (
+        contaminated.groupby("_contaminant")["intensity"].sum().sort_values(ascending=False)
+    )
+    top = list(ranked.index[:TOP_N_CONTAMINANTS])
+
+    result = {}
+    for run, group in df.groupby("run"):
+        total = totals.get(run, 0)
+        if total <= 0:
+            continue
+        run_data = {}
+        for name in top:
+            share = group.loc[group["_contaminant"] == name, "intensity"].sum()
+            run_data[name.replace(CONTAMINANT_MARKER, "")] = float(share / total * 100)
+        other = group.loc[
+            (group["_contaminant"] != CLEAN_LABEL)
+            & (~group["_contaminant"].isin(top)),
+            "intensity",
+        ].sum()
+        if other > 0:
+            run_data["Other"] = float(other / total * 100)
+        result[str(run)] = run_data
+
+    return result or None
+
+
+# ------------------------------------------------------------- search engine scores
+
+def calculate_search_engine_scores(id_df):
+    """Per-run distribution of a search-engine score, binned adaptively.
+
+    QPX score names are an open, free-form set (snake_case by convention), and their
+    ranges differ wildly -- a q-value or posterior error probability lives in [0, 1]
+    while a raw engine score can reach the hundreds. So the score is chosen from what
+    the project actually carries and the bins are derived from its observed range,
+    rather than assuming MaxQuant's fixed 0-300 Andromeda bins.
+
+    Returns ``(plot_data, score_name)`` or ``(None, None)``.
+    """
+    if id_df is None or getattr(id_df, "empty", True) or "run" not in id_df.columns:
+        return None, None
+
+    scores, score_name = _pick_score(id_df)
+    if scores is None:
+        log.debug("[Search Engine Scores] No usable score column; skipping.")
+        return None, None
+
+    frame = pd.DataFrame({"run": id_df["run"], "score": scores}).dropna(subset=["score"])
+    frame = frame[pd.to_numeric(frame["score"], errors="coerce").notna()]
+    if frame.empty:
+        return None, None
+
+    edges = _bin_edges(frame["score"])
+    if edges is None:
+        log.debug(f"[Search Engine Scores] '{score_name}' has no spread; skipping.")
+        return None, None
+
+    labels = [f"{edges[i]:.4g} ~ {edges[i + 1]:.4g}" for i in range(len(edges) - 1)]
+    frame["bin"] = pd.cut(
+        frame["score"], bins=edges, labels=labels, include_lowest=True, right=False
+    )
+
+    plot_data = {}
+    for run, group in frame.groupby("run"):
+        counts = group["bin"].value_counts()
+        plot_data[str(run)] = {label: int(counts.get(label, 0)) for label in labels}
+
+    log.info(
+        f"[Search Engine Scores] Using '{score_name}' over {len(labels)} bins "
+        f"across {len(plot_data)} run(s)."
+    )
+    return plot_data, score_name
+
+
+# Preferred in order: a real engine score, then generic confidence measures.
+_SCORE_PREFERENCE = ["andromeda_score", "hyperscore", "xcorr", "sage_hyperscore",
+                     "msgf_raw_score", "comet_xcorr", "diann_cscore"]
+
+
+def _pick_score(id_df):
+    """Choose a score column: a named engine score if present, else PEP, else q-value."""
+    if has_data(id_df, "additional_scores"):
+        available = _score_names(id_df["additional_scores"])
+        for preferred in _SCORE_PREFERENCE:
+            for name in available:
+                if name.lower() == preferred:
+                    return _extract_score(id_df["additional_scores"], name), name
+
+    if has_data(id_df, "posterior_error_probability"):
+        return pd.to_numeric(
+            id_df["posterior_error_probability"], errors="coerce"
+        ), "posterior_error_probability"
+
+    if has_data(id_df, "additional_scores"):
+        available = _score_names(id_df["additional_scores"])
+        for name in available:
+            if "qvalue" in name.lower().replace("-", "").replace("_", ""):
+                return _extract_score(id_df["additional_scores"], name), name
+        if available:
+            name = sorted(available)[0]
+            return _extract_score(id_df["additional_scores"], name), name
+
+    return None, None
+
+
+def _score_names(series, sample_size=5000):
+    names = set()
+    for cell in series.head(sample_size):
+        if cell is None:
+            continue
+        try:
+            for entry in cell:
+                if isinstance(entry, dict) and entry.get("score_name"):
+                    names.add(str(entry["score_name"]))
+        except TypeError:
+            continue
+    return names
+
+
+def _extract_score(series, name):
+    def pull(cell):
+        if cell is None:
+            return None
+        try:
+            for entry in cell:
+                if isinstance(entry, dict) and entry.get("score_name") == name:
+                    return entry.get("score_value")
+        except TypeError:
+            return None
+        return None
+
+    return pd.to_numeric(series.apply(pull), errors="coerce")
+
+
+def _bin_edges(scores, target_bins=20):
+    """Bin edges spanning the observed range, clipped to the 1st-99th percentile."""
+    numeric = pd.to_numeric(scores, errors="coerce").dropna()
+    if numeric.empty or numeric.nunique() < 2:
+        return None
+
+    low = float(numeric.quantile(0.01))
+    high = float(numeric.quantile(0.99))
+    if high <= low:
+        low, high = float(numeric.min()), float(numeric.max())
+    if high <= low:
+        return None
+
+    step = (high - low) / target_bins
+    return [low + step * i for i in range(target_bins + 1)]
+
+
+def draw_qpx_search_engine_scores(sub_section, plot_data, score_name):
+    """Bar plot of the chosen search-engine score distribution per run.
+
+    A dedicated drawer rather than general.draw_search_engine_scores, because that one
+    hard-codes a title per tool ("Andromeda", "Hyperscore") while the QPX score is
+    chosen at runtime from whatever the project carries.
+    """
+    from multiqc.plots import bargraph
+
+    from pmultiqc.modules.common.plots.general import plot_html_check
+    from pmultiqc.modules.core.section_groups import add_sub_section
+
+    if not plot_data:
+        return
+
+    pretty = score_name.replace("_", " ").title()
+    draw_config = {
+        "id": "qpx_search_engine_scores",
+        "title": f"Summary of {pretty}",
+        "cpswitch": True,
+        "cpswitch_c_active": False,
+        "tt_decimals": 0,
+        "ylab": "Count",
+        "save_data_file": False,
+    }
+
+    bar_html = plot_html_check(bargraph.plot(data=plot_data, pconfig=draw_config))
+
+    add_sub_section(
+        sub_section=sub_section,
+        plot=bar_html,
+        order=1,
+        description=f"Distribution of <code>{score_name}</code> per run.",
+        helptext=f"""
+            QPX stores engine scores as a free-form <code>additional_scores</code> list, so the
+            score shown is whichever the project actually carries -- here
+            <code>{score_name}</code>. Bin edges span the observed 1st-99th percentile
+            range rather than a fixed scale, because score ranges differ by orders of
+            magnitude between engines and between q-values, PEPs and raw scores.
+            """,
+    )

--- a/pmultiqc/modules/qpx/qpx_utils.py
+++ b/pmultiqc/modules/qpx/qpx_utils.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import pandas as pd
+
 from pmultiqc.modules.common.logging import get_logger
 from pmultiqc.modules.common.plots.general import (
     stat_pep_intensity
@@ -13,12 +15,22 @@ from pmultiqc.modules.common.common_utils import (
 log = get_logger("pmultiqc.modules.qpx.qpx_utils")
 
 
-def calculate_run_stat(psm_df_sub, proteins):
-    """Calculate statistics for a specific run."""
+def calculate_run_stat(psm_df_sub, proteins, unambiguous_peptides=None):
+    """Calculate statistics for a specific run.
+
+    ``unambiguous_peptides`` is the project-wide set of peptide sequences mapping to a
+    single protein group (see :func:`get_unambiguous_peptides`). It is passed in rather
+    than derived here because uniqueness is a property of the whole project, not of one
+    run. When it is None the count is reported as unavailable rather than as zero.
+    """
     peptides = set(psm_df_sub["peptidoform"])
 
-    # TODO need protein_accessions in psm.parquet
-    unique_peptides = set()
+    if unambiguous_peptides is None:
+        unique_peptides = None
+    elif "sequence" in psm_df_sub.columns:
+        unique_peptides = set(psm_df_sub["sequence"]) & unambiguous_peptides
+    else:
+        unique_peptides = None
 
     # 'modifications' is optional: writers may omit it, and the reader only loads
     # columns the file actually has.
@@ -32,14 +44,14 @@ def calculate_run_stat(psm_df_sub, proteins):
     stat_run = {
         "protein_num": len(proteins),
         "peptide_num": len(peptides),
-        "unique_peptide_num": len(unique_peptides),
+        "unique_peptide_num": len(unique_peptides) if unique_peptides is not None else "",
         "modified_peptide_num": len(modified_pep)
     }
 
     data_per_run = {
         "proteins": proteins,
         "peptides": peptides,
-        "unique_peptides": unique_peptides,
+        "unique_peptides": unique_peptides if unique_peptides is not None else set(),
         "modified_peps": modified_pep
     }
 
@@ -194,3 +206,58 @@ def _first_enzyme_value(cell):
         return str(cell).strip() or None
 
     return None
+
+
+def get_unambiguous_peptides(feature_df):
+    """Peptide sequences that map to exactly one protein group across the project.
+
+    Prefers the ``unique`` flag when the producer sets it (DIA-NN does; the
+    OpenMS-consensus route leaves it null). Otherwise derives it from the protein
+    accessions each sequence is observed with. Returns None when neither is possible,
+    so callers can distinguish "no unambiguous peptides" from "cannot tell".
+    """
+    if feature_df is None or getattr(feature_df, "empty", True):
+        return None
+    if "sequence" not in feature_df.columns:
+        return None
+
+    if "unique" in feature_df.columns and feature_df["unique"].notna().any():
+        flagged = feature_df[feature_df["unique"].fillna(False).astype(bool)]
+        log.info("[Identification] Unambiguous peptides taken from the 'unique' flag.")
+        return set(flagged["sequence"].dropna())
+
+    if "pg_accessions" not in feature_df.columns:
+        return None
+
+    accessions = feature_df["pg_accessions"].apply(_feature_accessions)
+    if not accessions.map(bool).any():
+        return None
+
+    df = pd.DataFrame({"sequence": feature_df["sequence"], "_acc": accessions})
+    df = df.dropna(subset=["sequence"])
+
+    per_sequence = df.groupby("sequence")["_acc"].apply(
+        lambda groups: set().union(*groups) if len(groups) else set()
+    )
+    unambiguous = {seq for seq, accs in per_sequence.items() if len(accs) == 1}
+
+    log.info(
+        f"[Identification] Unambiguous peptides derived from protein accessions: "
+        f"{len(unambiguous)} of {len(per_sequence)} sequences map to a single protein group."
+    )
+    return unambiguous
+
+
+def _feature_accessions(cell):
+    """Accession strings from feature.pg_accessions (a list of structs)."""
+    if cell is None:
+        return set()
+    try:
+        out = set()
+        for entry in cell:
+            value = entry.get("accession") if isinstance(entry, dict) else entry
+            if value is not None and str(value) != "":
+                out.add(str(value))
+        return out
+    except TypeError:
+        return set()

--- a/pmultiqc/modules/qpx/qpx_utils.py
+++ b/pmultiqc/modules/qpx/qpx_utils.py
@@ -20,9 +20,14 @@ def calculate_run_stat(psm_df_sub, proteins):
     # TODO need protein_accessions in psm.parquet
     unique_peptides = set()
 
-    modified_pep = set(
-        psm_df_sub[psm_df_sub["modifications"].notna()]["peptidoform"]
-    )
+    # 'modifications' is optional: writers may omit it, and the reader only loads
+    # columns the file actually has.
+    if "modifications" in psm_df_sub.columns:
+        modified_pep = set(
+            psm_df_sub[psm_df_sub["modifications"].notna()]["peptidoform"]
+        )
+    else:
+        modified_pep = set()
 
     stat_run = {
         "protein_num": len(proteins),

--- a/tests/test_qpx.py
+++ b/tests/test_qpx.py
@@ -299,7 +299,14 @@ class TestInternalCallSiteKeywords:
                     continue
                 callee, keywords = resolve(node)
                 defs = definitions.get(callee)
-                if not defs or len(defs) > 1 or defs[0][1]:
+                if not defs or any(has_kwargs for _, has_kwargs in defs):
+                    continue
+                # Several modules define same-named drawers (e.g. draw_peptides_table in
+                # both dia_utils and mzidentml_utils). That is still checkable as long as
+                # every definition accepts the same parameters -- only genuinely
+                # divergent signatures are ambiguous enough to skip.
+                param_sets = {frozenset(params) for params, _ in defs}
+                if len(param_sets) > 1:
                     continue
                 params = defs[0][0]
                 for keyword in keywords:

--- a/tests/test_qpx_design.py
+++ b/tests/test_qpx_design.py
@@ -1,0 +1,192 @@
+"""Tests for deriving an experimental design from quantms.io run/sample parquet."""
+
+import numpy as np
+import pandas as pd
+
+from pmultiqc.modules.qpx.qpx_design import (
+    _conditions,
+    _label_number,
+    _number_samples,
+    build_design_from_parquet,
+)
+
+
+def _run_df(rows=None):
+    """A run.parquet-shaped frame: 2 samples x 3 runs, LFQ, single fraction."""
+    if rows is None:
+        rows = [
+            ("run_A_01", "Sample 1", 1, 1),
+            ("run_A_02", "Sample 1", 1, 1),
+            ("run_B_01", "Sample 2", 1, 1),
+        ]
+    return pd.DataFrame(
+        {
+            "run_accession": [r[0] for r in rows],
+            "run_file_name": [r[0] for r in rows],
+            "file_name": [f"{r[0]}.raw" for r in rows],
+            "samples": [
+                np.array(
+                    [
+                        {
+                            "sample_accession": r[1],
+                            "label": "LFQ",
+                            "biological_replicate": r[2],
+                            "technical_replicate": 1,
+                        }
+                    ],
+                    dtype=object,
+                )
+                for r in rows
+            ],
+            "fraction": [r[3] for r in rows],
+            "enzymes": [np.array(["Trypsin"], dtype=object) for _ in rows],
+        }
+    )
+
+
+def _sample_df(spiked=("12500 amol", "125 amol")):
+    return pd.DataFrame(
+        {
+            "sample_accession": ["Sample 1", "Sample 2"],
+            "organism": ["Homo sapiens", "Homo sapiens"],
+            "cell_line": ["K562", "K562"],
+            "spiked_compound": list(spiked),
+        }
+    )
+
+
+class TestBuildDesign:
+    def test_produces_read_openms_design_schema(self):
+        sample_df, file_df = build_design_from_parquet(_run_df(), _sample_df())
+
+        assert list(file_df.columns) == [
+            "FractionGroup", "Fraction", "Label", "Sample", "Filename", "Run",
+        ]
+        assert list(sample_df.columns) == ["Sample", "Condition", "BioReplicate"]
+
+    def test_run_to_sample_mapping(self):
+        _, file_df = build_design_from_parquet(_run_df(), _sample_df())
+
+        assert len(file_df) == 3
+        assert dict(zip(file_df["Run"], file_df["Sample"])) == {
+            "run_A_01": 1,
+            "run_A_02": 1,
+            "run_B_01": 2,
+        }
+
+    def test_sample_and_label_are_integers(self):
+        """Downstream code does file_df["Sample"].astype(int)."""
+        sample_df, file_df = build_design_from_parquet(_run_df(), _sample_df())
+
+        file_df["Sample"].astype(int)  # must not raise
+        assert all(isinstance(v, (int, np.integer)) for v in file_df["Sample"])
+        assert all(isinstance(v, (int, np.integer)) for v in file_df["Label"])
+        assert all(int(v) == 1 for v in file_df["Label"]), "LFQ is a single channel"
+        assert all(isinstance(int(v), int) for v in sample_df["BioReplicate"])
+
+    def test_condition_uses_the_varying_characteristic(self):
+        sample_df, _ = build_design_from_parquet(_run_df(), _sample_df())
+
+        # cell_line is constant, spiked_compound varies -> spiked_compound wins.
+        assert dict(zip(sample_df["Sample"], sample_df["Condition"])) == {
+            1: "12500 amol",
+            2: "125 amol",
+        }
+
+    def test_multiple_varying_characteristics_use_key_value_form(self):
+        samples = _sample_df()
+        samples["cell_line"] = ["K562", "HeLa"]
+        sample_df, _ = build_design_from_parquet(_run_df(), samples)
+
+        for condition in sample_df["Condition"]:
+            assert "=" in condition and ";" in condition
+            assert "cell_line=" in condition and "spiked_compound=" in condition
+
+    def test_no_varying_characteristic_falls_back_to_a_constant(self):
+        sample_df, _ = build_design_from_parquet(
+            _run_df(), _sample_df(spiked=("125 amol", "125 amol"))
+        )
+        assert set(sample_df["Condition"]) == {"Homo sapiens"}
+
+    def test_works_without_sample_parquet(self):
+        sample_df, file_df = build_design_from_parquet(_run_df(), None)
+
+        assert len(file_df) == 3
+        assert set(sample_df["Sample"]) == {1, 2}
+        assert set(sample_df["Condition"]) == {"not available"}
+
+    def test_tmt_labels_map_to_channels(self):
+        run_df = _run_df()
+        # One multiplexed run carrying both samples in two TMT channels.
+        multiplexed = np.array(
+            [
+                {"sample_accession": "Sample 1", "label": "TMT126",
+                 "biological_replicate": 1, "technical_replicate": 1},
+                {"sample_accession": "Sample 2", "label": "TMT127N",
+                 "biological_replicate": 1, "technical_replicate": 1},
+            ],
+            dtype=object,
+        )
+        samples = list(run_df["samples"])
+        samples[0] = multiplexed
+        run_df["samples"] = samples
+        _, file_df = build_design_from_parquet(run_df, _sample_df())
+
+        first_run = file_df[file_df["Run"] == "run_A_01"]
+        assert sorted(first_run["Label"]) == [1, 2]
+        assert sorted(first_run["Sample"]) == [1, 2]
+
+    def test_multi_fraction_runs_are_kept_separate(self):
+        run_df = _run_df(
+            [("run_A_f1", "Sample 1", 1, 1), ("run_A_f2", "Sample 1", 1, 2)]
+        )
+        _, file_df = build_design_from_parquet(run_df, _sample_df())
+
+        assert sorted(file_df["Fraction"]) == [1, 2]
+        assert set(file_df["Sample"]) == {1}
+
+
+class TestGracefulDegradation:
+    """A project that cannot supply a design must fall back, never emit a broken one."""
+
+    def test_none_run_df(self):
+        assert build_design_from_parquet(None, _sample_df()) == (None, None)
+
+    def test_empty_run_df(self):
+        assert build_design_from_parquet(pd.DataFrame(), _sample_df()) == (None, None)
+
+    def test_run_df_without_samples_column(self):
+        df = pd.DataFrame({"run_file_name": ["a"], "fraction": [1]})
+        assert build_design_from_parquet(df, _sample_df()) == (None, None)
+
+    def test_run_df_with_empty_sample_lists(self):
+        df = _run_df()
+        df["samples"] = [np.array([], dtype=object) for _ in range(len(df))]
+        assert build_design_from_parquet(df, _sample_df()) == (None, None)
+
+
+class TestHelpers:
+    def test_number_samples_prefers_trailing_digits(self):
+        assert _number_samples(["Sample 1", "Sample 2"]) == {"Sample 1": 1, "Sample 2": 2}
+
+    def test_number_samples_falls_back_to_order_when_ambiguous(self):
+        # Duplicate trailing numbers cannot be used as ids.
+        assert _number_samples(["A_1", "B_1"]) == {"A_1": 1, "B_1": 2}
+
+    def test_number_samples_falls_back_when_no_digits(self):
+        assert _number_samples(["alpha", "beta"]) == {"alpha": 1, "beta": 2}
+
+    def test_label_number(self):
+        assert _label_number("LFQ") == 1
+        assert _label_number(None) == 1
+        assert _label_number("TMT126") == 1
+        assert _label_number("TMT131C") == 11
+        assert _label_number("3") == 3
+        assert _label_number("something-unknown") == 1
+
+    def test_conditions_ignores_accession_columns(self):
+        # sample_accession varies by definition; it must not become the Condition.
+        df = pd.DataFrame(
+            {"sample_accession": ["S1", "S2"], "organism": ["Homo sapiens"] * 2}
+        )
+        assert set(_conditions(df, ["S1", "S2"]).values()) == {"Homo sapiens"}

--- a/tests/test_qpx_heatmap.py
+++ b/tests/test_qpx_heatmap.py
@@ -205,3 +205,48 @@ class TestProteinIntensity:
 
     def test_empty_input(self):
         assert get_protein_intensity(None, None) == [{}, {}]
+
+
+class TestSelectColumns:
+    """The reader omits absent columns, so downstream selection must be guarded."""
+
+    def test_returns_frame_when_all_present(self):
+        from pmultiqc.modules.qpx.qpx_io import select_columns
+
+        df = pd.DataFrame({"a": [1], "b": [2], "c": [3]})
+        out = select_columns(df, ["a", "b"], "ctx")
+
+        assert list(out.columns) == ["a", "b"]
+
+    def test_returns_none_when_a_column_is_missing(self):
+        from pmultiqc.modules.qpx.qpx_io import select_columns
+
+        df = pd.DataFrame({"a": [1]})
+        assert select_columns(df, ["a", "missing"], "ctx") is None
+
+    def test_returns_none_for_empty_or_absent_frame(self):
+        from pmultiqc.modules.qpx.qpx_io import select_columns
+
+        assert select_columns(None, ["a"], "ctx") is None
+        assert select_columns(pd.DataFrame(), ["a"], "ctx") is None
+
+    def test_result_is_a_copy(self):
+        from pmultiqc.modules.qpx.qpx_io import select_columns
+
+        df = pd.DataFrame({"a": [1]})
+        out = select_columns(df, ["a"], "ctx")
+        out.loc[0, "a"] = 99
+
+        assert df.loc[0, "a"] == 1, "caller mutations must not touch the source frame"
+
+
+class TestRunStatWithoutModifications:
+    def test_missing_modifications_column_is_tolerated(self):
+        from pmultiqc.modules.qpx.qpx_utils import calculate_run_stat
+
+        df = pd.DataFrame({"peptidoform": ["A", "B"]})
+        stat, data = calculate_run_stat(df, {"P1"})
+
+        assert stat["peptide_num"] == 2
+        assert stat["modified_peptide_num"] == 0
+        assert data["modified_peps"] == set()

--- a/tests/test_qpx_heatmap.py
+++ b/tests/test_qpx_heatmap.py
@@ -1,0 +1,207 @@
+"""Tests for the QPX QC heatmap and protein-level quantification."""
+
+import numpy as np
+import pandas as pd
+
+from pmultiqc.modules.qpx.qpx_heatmap import (
+    INTENSITY_REFERENCE,
+    METRIC_ORDER,
+    _contaminant_scores,
+    _oversampling_scores,
+    _peptide_intensity_scores,
+    _pep_missing_value_scores,
+    _variance_scores,
+    calculate_qpx_heatmap,
+)
+from pmultiqc.modules.qpx.qpx_quant import (
+    create_qpx_protein_table,
+    get_protein_intensity,
+)
+
+
+def _psm_df():
+    return pd.DataFrame(
+        {
+            "run": ["r1"] * 4 + ["r2"] * 4,
+            "peptidoform": ["A", "A", "B", "C", "A", "B", "D", "D"],
+            "charge": [2, 2, 3, 2, 2, 2, 3, 3],
+            "rt": [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0],
+            "sequence": ["PEPA", "PEPA", "PEPB", "PEPC", "PEPA", "PEPB", "PEPD", "PEPD"],
+        }
+    )
+
+
+def _pg_df(contaminant=None):
+    df = pd.DataFrame(
+        {
+            "run": ["r1", "r1", "r2", "r2"],
+            "anchor_protein": ["P1", "CONT_P2", "P1", "CONT_P2"],
+            "intensity": [900.0, 100.0, 800.0, 200.0],
+            "global_qvalue": [0.001, 0.02, 0.002, 0.03],
+        }
+    )
+    if contaminant is not None:
+        df["contaminant"] = contaminant
+    return df
+
+
+def _feature_df(intensity=1000.0):
+    return pd.DataFrame(
+        {
+            "run": ["r1", "r1", "r2", "r2"],
+            "sequence": ["PEPA", "PEPB", "PEPA", "PEPD"],
+            "anchor_protein": ["P1", "P1", "P1", "P2"],
+            "intensities": [
+                [{"label": "LFQ", "intensity": intensity}] for _ in range(4)
+            ],
+        }
+    )
+
+
+class TestHeatmapAssembly:
+    def test_full_metric_set(self):
+        scores, xnames, ynames = calculate_qpx_heatmap(
+            _psm_df(), _pg_df(), _feature_df(), {"r1": {0: 8, 1: 2}, "r2": {0: 5, 1: 5}}, "CONT"
+        )
+
+        assert xnames == METRIC_ORDER
+        assert ynames == ["r1", "r2"]
+        assert len(scores) == 2 and all(len(row) == len(METRIC_ORDER) for row in scores)
+        assert all(0.0 <= v <= 1.0 for row in scores for v in row)
+
+    def test_metrics_without_data_are_dropped(self):
+        # No pg -> no Contaminants; no feature -> no Peptide Intensity;
+        # no missed-cleavage counts -> no Missed Cleavages or its variance.
+        _, xnames, _ = calculate_qpx_heatmap(_psm_df(), None, None, {}, "CONT")
+
+        assert xnames == ["Charge", "ID rate over RT", "MS2 OverSampling", "Pep Missing Values"]
+
+    def test_metric_covering_only_some_runs_is_dropped(self):
+        """A partially-covered metric must not be padded with invented cells."""
+        _, xnames, ynames = calculate_qpx_heatmap(
+            _psm_df(), None, None, {"r1": {0: 8, 1: 2}}, "CONT"
+        )
+
+        assert ynames == ["r1", "r2"]
+        assert "Missed Cleavages" not in xnames
+
+    def test_no_psm_data_returns_empty(self):
+        assert calculate_qpx_heatmap(None, _pg_df(), _feature_df(), {}, "CONT") == ([], [], [])
+        assert calculate_qpx_heatmap(
+            pd.DataFrame(), _pg_df(), _feature_df(), {}, "CONT"
+        ) == ([], [], [])
+
+    def test_score_ordering_matches_xnames(self):
+        scores, xnames, ynames = calculate_qpx_heatmap(
+            _psm_df(), _pg_df(), _feature_df(), {"r1": {0: 10}, "r2": {0: 5, 1: 5}}, "CONT"
+        )
+        mc = scores[ynames.index("r1")][xnames.index("Missed Cleavages")]
+        assert mc == 1.0, "r1 has only zero-missed-cleavage PSMs"
+        assert scores[ynames.index("r2")][xnames.index("Missed Cleavages")] == 0.5
+
+
+class TestContaminants:
+    def test_uses_contaminant_flag_when_present(self):
+        scores = _contaminant_scores(_pg_df(contaminant=[False, True, False, True]), "CONT")
+        # r1: 100 of 1000 contaminant -> 0.9 ; r2: 200 of 1000 -> 0.8
+        assert scores == {"r1": 0.9, "r2": 0.8}
+
+    def test_falls_back_to_accession_affix(self):
+        scores = _contaminant_scores(_pg_df(), "CONT")
+        assert scores == {"r1": 0.9, "r2": 0.8}
+
+    def test_flag_takes_precedence_over_affix(self):
+        # Nothing flagged -> score 1.0 even though accessions carry the affix.
+        scores = _contaminant_scores(_pg_df(contaminant=[False] * 4), "CONT")
+        assert scores == {"r1": 1.0, "r2": 1.0}
+
+    def test_no_intensity_column(self):
+        assert _contaminant_scores(pd.DataFrame({"run": ["r1"]}), "CONT") == {}
+
+
+class TestPeptideIntensity:
+    def test_scaled_against_reference(self):
+        scores = _peptide_intensity_scores(_feature_df(intensity=INTENSITY_REFERENCE / 4))
+        assert scores == {"r1": 0.25, "r2": 0.25}
+
+    def test_clamped_at_one(self):
+        scores = _peptide_intensity_scores(_feature_df(intensity=INTENSITY_REFERENCE * 10))
+        assert scores == {"r1": 1.0, "r2": 1.0}
+
+    def test_zero_intensities_ignored(self):
+        assert _peptide_intensity_scores(_feature_df(intensity=0.0)) == {}
+
+
+class TestOtherMetrics:
+    def test_oversampling_counts_single_hit_precursors(self):
+        scores = _oversampling_scores(_psm_df())
+        # r1 precursors: A/2 seen twice, B/3 once, C/2 once -> 2 of 3 single
+        assert scores["r1"] == 2 / 3
+        # r2: A/2 once, B/2 once, D/3 twice -> 2 of 3
+        assert scores["r2"] == 2 / 3
+
+    def test_pep_missing_values_is_share_of_global(self):
+        scores = _pep_missing_value_scores(_psm_df())
+        # global peptidoforms = {A,B,C,D}; r1 has {A,B,C}, r2 has {A,B,D}
+        assert scores == {"r1": 0.75, "r2": 0.75}
+
+    def test_variance_scores(self):
+        assert _variance_scores({"r1": 1.0, "r2": 0.5}) == {"r1": 0.75, "r2": 0.75}
+        assert _variance_scores({}) == {}
+
+
+class TestProteinQuantTable:
+    def test_table_contents(self):
+        table, headers = create_qpx_protein_table(
+            _pg_df(), _feature_df(), pd.DataFrame(), pd.DataFrame()
+        )
+
+        assert set(headers) >= {"ProteinName", "Average Intensity", "Peptides_Number"}
+        rows = {entry["ProteinName"]: entry for entry in table.values()}
+        assert set(rows) == {"P1", "CONT_P2"}
+        # P1: mean(900, 800) = 850
+        assert rows["P1"]["Average Intensity"] == float(np.log10(850.0))
+        assert rows["P1"]["Peptides_Number"] == 2, "PEPA and PEPB map to P1"
+        assert rows["P1"]["Global Q-value"] == 0.001, "best (lowest) q-value"
+
+    def test_sorted_by_intensity_descending(self):
+        table, _ = create_qpx_protein_table(
+            _pg_df(), _feature_df(), pd.DataFrame(), pd.DataFrame()
+        )
+        intensities = [entry["Average Intensity"] for entry in table.values()]
+        assert intensities == sorted(intensities, reverse=True)
+
+    def test_condition_columns_added_when_design_available(self):
+        sample_df = pd.DataFrame({"Sample": [1, 2], "Condition": ["A", "B"]})
+        file_df = pd.DataFrame({"Sample": [1, 2], "Run": ["r1", "r2"]})
+
+        table, headers = create_qpx_protein_table(_pg_df(), _feature_df(), sample_df, file_df)
+
+        assert "A" in headers and "B" in headers
+        rows = {entry["ProteinName"]: entry for entry in table.values()}
+        assert rows["P1"]["A"] == float(np.log10(900.0))
+        assert rows["P1"]["B"] == float(np.log10(800.0))
+
+    def test_returns_none_without_usable_data(self):
+        assert create_qpx_protein_table(None, None, None, None) == (None, None)
+        assert create_qpx_protein_table(pd.DataFrame(), None, None, None) == (None, None)
+
+        no_intensity = pd.DataFrame({"run": ["r1"], "anchor_protein": ["P1"], "intensity": [0.0]})
+        assert create_qpx_protein_table(no_intensity, None, None, None) == (None, None)
+
+
+class TestProteinIntensity:
+    def test_by_run_and_by_sample(self):
+        file_df = pd.DataFrame({"Sample": [1, 2], "Run": ["r1", "r2"]})
+        by_run, by_sample = get_protein_intensity(_pg_df(), file_df)
+
+        assert set(by_run) == {"r1", "r2"}
+        assert set(by_sample) == {"Sample 1", "Sample 2"}
+
+    def test_by_run_only_without_design(self):
+        by_run, by_sample = get_protein_intensity(_pg_df(), pd.DataFrame())
+        assert set(by_run) == {"r1", "r2"}
+        assert by_sample == {}
+
+    def test_empty_input(self):
+        assert get_protein_intensity(None, None) == [{}, {}]

--- a/tests/test_qpx_heatmap.py
+++ b/tests/test_qpx_heatmap.py
@@ -110,10 +110,22 @@ class TestContaminants:
         scores = _contaminant_scores(_pg_df(), "CONT")
         assert scores == {"r1": 0.9, "r2": 0.8}
 
-    def test_flag_takes_precedence_over_affix(self):
-        # Nothing flagged -> score 1.0 even though accessions carry the affix.
+    def test_affix_match_is_unioned_with_the_flag(self):
+        """A False flag must not hide accessions the affix matches.
+
+        The OpenMS-consensus converter reports contaminant=False for the "Cont_"-prefixed
+        accessions these projects actually use, so trusting the flag alone reports a
+        confident 0% contamination for data that is 5-10% contaminant.
+        """
         scores = _contaminant_scores(_pg_df(contaminant=[False] * 4), "CONT")
-        assert scores == {"r1": 1.0, "r2": 1.0}
+        assert scores == {"r1": 0.9, "r2": 0.8}
+
+    def test_case_insensitive_affix(self):
+        df = _pg_df()
+        df["anchor_protein"] = ["P1", "sp|Cont_P00330|ADH1", "P1", "sp|Cont_P00330|ADH1"]
+        df["pg_accessions"] = [["P1"], ["sp|Cont_P00330|ADH1"], ["P1"], ["sp|Cont_P00330|ADH1"]]
+        scores = _contaminant_scores(df, "CONT")
+        assert scores == {"r1": 0.9, "r2": 0.8}, "'Cont_' must match affix 'CONT'"
 
     def test_no_intensity_column(self):
         assert _contaminant_scores(pd.DataFrame({"run": ["r1"]}), "CONT") == {}

--- a/tests/test_qpx_sections.py
+++ b/tests/test_qpx_sections.py
@@ -382,3 +382,90 @@ class TestSummariseBoxData:
         as_dict = {"r1": list(np.random.default_rng(2).normal(0, 1, 500))}
         assert isinstance(summarise_box_data(as_dict), dict)
         assert isinstance(summarise_box_data([as_dict]), list)
+
+
+class TestReviewRegressions:
+    """Guards for the defects the code review surfaced."""
+
+    def test_feature_columns_cover_the_psm_fallback(self):
+        """DIA-NN has no psm.parquet, so feature must carry what those plots read."""
+        from pmultiqc.modules.qpx.qpx_io import QPX_COLUMNS
+
+        for column in ["scan", "posterior_error_probability", "additional_scores"]:
+            assert column in QPX_COLUMNS["feature"], column
+
+    def test_psm_reads_additional_scores(self):
+        """Search-engine scores live here; without it the whole path is dead code."""
+        from pmultiqc.modules.qpx.qpx_io import QPX_COLUMNS
+
+        assert "additional_scores" in QPX_COLUMNS["psm"]
+
+    def test_display_name_falls_back_to_the_key_not_an_index(self):
+        from pmultiqc.modules.qpx.qpx_quant import create_qpx_protein_table
+
+        pg = pd.DataFrame(
+            {
+                "run": ["r1", "r1"],
+                "pg_accessions": [["P1"], ["P2"]],
+                "intensity": [10.0, 20.0],
+            }
+        )
+        table, _ = create_qpx_protein_table(pg, None, None, None)
+        names = {e["ProteinName"] for e in table.values()}
+
+        assert names == {"P1", "P2"}, "must not label proteins '0'/'1'"
+
+    def test_peptides_number_header_only_when_populated(self):
+        from pmultiqc.modules.qpx.qpx_quant import create_qpx_protein_table
+
+        pg = pd.DataFrame(
+            {"run": ["r1"], "pg_accessions": [["P1"]], "intensity": [10.0]}
+        )
+        # feature keys on a different protein group -> no counts join
+        feature = pd.DataFrame(
+            {"sequence": ["PEP"], "pg_accessions": [[{"accession": "OTHER"}]]}
+        )
+        _, headers = create_qpx_protein_table(pg, feature, None, None)
+
+        assert "Peptides_Number" not in headers
+
+    def test_explicit_contaminant_flag_is_not_overridden(self):
+        """The affix may only supplement a flag that marks nothing, never flip a True/False."""
+        from pmultiqc.modules.qpx.qpx_sections import resolve_contaminant_flags
+
+        df = pd.DataFrame(
+            {
+                "anchor_protein": ["sp|Cont_A|X", "sp|B|Y"],
+                "pg_accessions": [["sp|Cont_A|X"], ["sp|B|Y"]],
+                "contaminant": [False, True],
+            }
+        )
+        flags = resolve_contaminant_flags(df, "CONT")
+
+        assert list(flags) == [False, True], "producer flag wins when it marks anything"
+
+    def test_affix_supplements_an_empty_flag(self):
+        from pmultiqc.modules.qpx.qpx_sections import resolve_contaminant_flags
+
+        df = pd.DataFrame(
+            {
+                "anchor_protein": ["sp|Cont_A|X", "sp|B|Y"],
+                "pg_accessions": [["sp|Cont_A|X"], ["sp|B|Y"]],
+                "contaminant": [False, False],
+            }
+        )
+        assert list(resolve_contaminant_flags(df, "CONT")) == [True, False]
+
+    def test_sample_merge_survives_mixed_dtypes(self):
+        """Sample is int from the derived design and str from an OpenMS design file."""
+        from pmultiqc.modules.qpx.qpx_quant import create_qpx_protein_table
+
+        pg = pd.DataFrame(
+            {"run": ["r1"], "pg_accessions": [["P1"]], "intensity": [10.0]}
+        )
+        sample_df = pd.DataFrame({"Sample": ["1"], "Condition": ["A"]})   # str
+        file_df = pd.DataFrame({"Sample": [1], "Run": ["r1"]})            # int
+
+        table, headers = create_qpx_protein_table(pg, None, sample_df, file_df)
+
+        assert "A" in headers, "condition column must survive the dtype mismatch"

--- a/tests/test_qpx_sections.py
+++ b/tests/test_qpx_sections.py
@@ -324,3 +324,62 @@ class TestContaminantsZeroSignal:
             }
         )
         assert calculate_contaminants(pg, "CONT") == (None, None)
+
+
+class TestTrimBoxOutliers:
+    """MultiQC's box plot ignores xmin/xmax, so readability comes from the data."""
+
+    @staticmethod
+    def _long_tailed():
+        rng = np.random.default_rng(0)
+        core = list(rng.normal(26, 1.2, 5000))
+        return [{"r1": core + [20.3, 36.1, 35.0, 19.8]}]
+
+    def test_tightens_the_range(self):
+        from pmultiqc.modules.common.plots.general import trim_box_outliers
+
+        data = self._long_tailed()
+        before = data[0]["r1"]
+        trimmed, dropped = trim_box_outliers(data)
+        after = trimmed[0]["r1"]
+
+        assert dropped > 0
+        assert (max(after) - min(after)) < (max(before) - min(before)) / 2
+
+    def test_leaves_quartiles_essentially_unchanged(self):
+        from pmultiqc.modules.common.plots.general import trim_box_outliers
+
+        data = self._long_tailed()
+        before = np.percentile(data[0]["r1"], [25, 50, 75])
+        trimmed, _ = trim_box_outliers(data)
+        after = np.percentile(trimmed[0]["r1"], [25, 50, 75])
+
+        assert np.allclose(before, after, atol=0.1), "trimming must not move the box"
+
+    def test_small_series_untouched(self):
+        from pmultiqc.modules.common.plots.general import trim_box_outliers
+
+        data = [{"r1": [1.0, 2.0, 100.0]}]
+        trimmed, dropped = trim_box_outliers(data)
+
+        assert dropped == 0 and trimmed == data
+
+    def test_never_empties_a_sample(self):
+        from pmultiqc.modules.common.plots.general import trim_box_outliers
+
+        rng = np.random.default_rng(1)
+        data = [{"bulk": list(rng.normal(0, 1, 5000)), "outlier_only": [999.0, 998.0]}]
+        trimmed, _ = trim_box_outliers(data)
+
+        assert trimmed[0]["outlier_only"], "a sample must not vanish from the plot"
+
+    def test_preserves_shape(self):
+        from pmultiqc.modules.common.plots.general import trim_box_outliers
+
+        rng = np.random.default_rng(2)
+        as_dict = {"r1": list(rng.normal(0, 1, 500))}
+        trimmed, _ = trim_box_outliers(as_dict)
+        assert isinstance(trimmed, dict)
+
+        trimmed_list, _ = trim_box_outliers([as_dict])
+        assert isinstance(trimmed_list, list)

--- a/tests/test_qpx_sections.py
+++ b/tests/test_qpx_sections.py
@@ -332,8 +332,9 @@ class TestSummariseBoxData:
 
     @staticmethod
     def _raw():
+        # Over FLAT_THRESHOLD so summarisation actually engages.
         rng = np.random.default_rng(0)
-        return [{"r1": list(rng.normal(26, 1.2, 50000)) + [36.1, 20.3]}]
+        return [{"r1": list(rng.normal(26, 1.2, 120000)) + [36.1, 20.3]}]
 
     def test_collapses_to_six_numbers(self):
         from pmultiqc.modules.common.plots.general import summarise_box_data
@@ -369,6 +370,16 @@ class TestSummariseBoxData:
 
         stats = summarise_box_data(raw)
         assert sum(len(v) for v in stats[0].values()) < FLAT_THRESHOLD
+
+    def test_small_data_is_left_raw(self):
+        """Below the flat threshold the plot is already interactive, so keep the raw
+        points -- summarising would drop the outlier dots for no benefit."""
+        from pmultiqc.modules.common.plots.general import summarise_box_data
+
+        small = [{"r1": list(np.random.default_rng(3).normal(0, 1, 5000))}]
+        out = summarise_box_data(small)
+
+        assert out == small, "small series must be returned untouched"
 
     def test_already_summarised_is_passed_through(self):
         from pmultiqc.modules.common.plots.general import summarise_box_data

--- a/tests/test_qpx_sections.py
+++ b/tests/test_qpx_sections.py
@@ -326,60 +326,59 @@ class TestContaminantsZeroSignal:
         assert calculate_contaminants(pg, "CONT") == (None, None)
 
 
-class TestTrimBoxOutliers:
-    """MultiQC's box plot ignores xmin/xmax, so readability comes from the data."""
+class TestSummariseBoxData:
+    """MultiQC flips a plot to a static image past 100k points; that image does not
+    fill the panel. Summarising to box statistics keeps it interactive."""
 
     @staticmethod
-    def _long_tailed():
+    def _raw():
         rng = np.random.default_rng(0)
-        core = list(rng.normal(26, 1.2, 5000))
-        return [{"r1": core + [20.3, 36.1, 35.0, 19.8]}]
+        return [{"r1": list(rng.normal(26, 1.2, 50000)) + [36.1, 20.3]}]
 
-    def test_tightens_the_range(self):
-        from pmultiqc.modules.common.plots.general import trim_box_outliers
+    def test_collapses_to_six_numbers(self):
+        from pmultiqc.modules.common.plots.general import summarise_box_data
 
-        data = self._long_tailed()
-        before = data[0]["r1"]
-        trimmed, dropped = trim_box_outliers(data)
-        after = trimmed[0]["r1"]
+        stats = summarise_box_data(self._raw())[0]["r1"]
 
-        assert dropped > 0
-        assert (max(after) - min(after)) < (max(before) - min(before)) / 2
+        assert set(stats) == {"min", "q1", "median", "q3", "max", "mean"}
 
-    def test_leaves_quartiles_essentially_unchanged(self):
-        from pmultiqc.modules.common.plots.general import trim_box_outliers
+    def test_quartiles_match_the_raw_data(self):
+        from pmultiqc.modules.common.plots.general import summarise_box_data
 
-        data = self._long_tailed()
-        before = np.percentile(data[0]["r1"], [25, 50, 75])
-        trimmed, _ = trim_box_outliers(data)
-        after = np.percentile(trimmed[0]["r1"], [25, 50, 75])
+        raw = self._raw()
+        expected = np.percentile(raw[0]["r1"], [25, 50, 75])
+        stats = summarise_box_data(raw)[0]["r1"]
 
-        assert np.allclose(before, after, atol=0.1), "trimming must not move the box"
+        assert np.allclose(
+            [stats["q1"], stats["median"], stats["q3"]], expected, atol=1e-6
+        )
 
-    def test_small_series_untouched(self):
-        from pmultiqc.modules.common.plots.general import trim_box_outliers
+    def test_fences_exclude_outliers(self):
+        from pmultiqc.modules.common.plots.general import summarise_box_data
 
-        data = [{"r1": [1.0, 2.0, 100.0]}]
-        trimmed, dropped = trim_box_outliers(data)
+        stats = summarise_box_data(self._raw())[0]["r1"]
 
-        assert dropped == 0 and trimmed == data
+        assert stats["max"] < 36.1, "upper fence must exclude the extreme point"
+        assert stats["min"] > 20.3, "lower fence must exclude the extreme point"
 
-    def test_never_empties_a_sample(self):
-        from pmultiqc.modules.common.plots.general import trim_box_outliers
+    def test_point_count_drops_below_the_flat_threshold(self):
+        from pmultiqc.modules.common.plots.general import FLAT_THRESHOLD, summarise_box_data
 
-        rng = np.random.default_rng(1)
-        data = [{"bulk": list(rng.normal(0, 1, 5000)), "outlier_only": [999.0, 998.0]}]
-        trimmed, _ = trim_box_outliers(data)
+        raw = [{f"r{i}": list(np.random.default_rng(i).normal(26, 1, 40000)) for i in range(6)}]
+        assert sum(len(v) for v in raw[0].values()) > FLAT_THRESHOLD
 
-        assert trimmed[0]["outlier_only"], "a sample must not vanish from the plot"
+        stats = summarise_box_data(raw)
+        assert sum(len(v) for v in stats[0].values()) < FLAT_THRESHOLD
+
+    def test_already_summarised_is_passed_through(self):
+        from pmultiqc.modules.common.plots.general import summarise_box_data
+
+        stats = {"r1": {"min": 1, "q1": 2, "median": 3, "q3": 4, "max": 5}}
+        assert summarise_box_data([stats])[0] == stats
 
     def test_preserves_shape(self):
-        from pmultiqc.modules.common.plots.general import trim_box_outliers
+        from pmultiqc.modules.common.plots.general import summarise_box_data
 
-        rng = np.random.default_rng(2)
-        as_dict = {"r1": list(rng.normal(0, 1, 500))}
-        trimmed, _ = trim_box_outliers(as_dict)
-        assert isinstance(trimmed, dict)
-
-        trimmed_list, _ = trim_box_outliers([as_dict])
-        assert isinstance(trimmed_list, list)
+        as_dict = {"r1": list(np.random.default_rng(2).normal(0, 1, 500))}
+        assert isinstance(summarise_box_data(as_dict), dict)
+        assert isinstance(summarise_box_data([as_dict]), list)

--- a/tests/test_qpx_sections.py
+++ b/tests/test_qpx_sections.py
@@ -116,7 +116,8 @@ class TestContaminants:
         per_run, top_n = calculate_contaminants(self._pg([False, True]), "CONT")
 
         assert per_run["r1"]["Potential Contaminants"] == 10.0
-        assert top_n["r1"]["CONT_P2"] == 10.0
+        assert top_n["plot_data"]["r1"]["CONT_P2"] == 10.0
+        assert "CONT_P2" in top_n["cats"]
 
     def test_all_null_flag_falls_back_to_the_affix(self):
         """Null means unknown, so fall through rather than claiming 0%."""
@@ -129,13 +130,39 @@ class TestContaminants:
 
     def test_known_clean_is_skipped(self):
         """Known-clean is a real answer, but an all-zero chart conveys nothing."""
-        assert calculate_contaminants(self._pg([False, False]), "CONT") == (None, None)
+        clean = pd.DataFrame(
+            {
+                "run": ["r1", "r1"],
+                "anchor_protein": ["P1", "P2"],
+                "pg_accessions": [["P1"], ["P2"]],
+                "intensity": [900.0, 100.0],
+                "contaminant": [False, False],
+            }
+        )
+        assert calculate_contaminants(clean, "CONT") == (None, None)
+
+    def test_affix_match_overrides_a_false_flag(self):
+        """Converters disagree: OpenMS-consensus reports False for Cont_-prefixed
+        accessions, so an explicit affix must still find them."""
+        mislabelled = pd.DataFrame(
+            {
+                "run": ["r1", "r1"],
+                "anchor_protein": ["sp|P1|A", "sp|Cont_P00330|ADH1_YEAST"],
+                "pg_accessions": [["sp|P1|A"], ["sp|Cont_P00330|ADH1_YEAST"]],
+                "intensity": [900.0, 100.0],
+                "contaminant": [False, False],
+            }
+        )
+        per_run, top_n = calculate_contaminants(mislabelled, "CONT")
+
+        assert per_run["r1"]["Potential Contaminants"] == 10.0, "case-insensitive match"
+        assert top_n is not None
 
     def test_partial_contamination_still_reports_top_n(self):
         per_run, top_n = calculate_contaminants(self._pg([False, True]), "CONT")
 
         assert per_run["r1"]["Potential Contaminants"] == 10.0
-        assert set(top_n["r1"]) == {"CONT_P2"}
+        assert set(top_n["plot_data"]["r1"]) == {"CONT_P2"}
 
 
 class TestSearchEngineScores:

--- a/tests/test_qpx_sections.py
+++ b/tests/test_qpx_sections.py
@@ -1,0 +1,299 @@
+"""Tests for the adaptive QPX sections: mass error, oversampling, contaminants, scores."""
+
+import numpy as np
+import pandas as pd
+
+from pmultiqc.modules.qpx.qpx_io import has_data
+from pmultiqc.modules.qpx.qpx_mass_error import calculate_mass_error
+from pmultiqc.modules.qpx.qpx_quant import (
+    calculate_intensity_std,
+    create_qpx_peptide_table,
+    protein_group_key,
+    protein_intensity_pca,
+)
+from pmultiqc.modules.qpx.qpx_sections import (
+    calculate_contaminants,
+    calculate_oversampling,
+    calculate_search_engine_scores,
+)
+
+
+def _scores(*pairs):
+    return [{"score_name": n, "score_value": v, "higher_better": False} for n, v in pairs]
+
+
+class TestHasData:
+    """Presence is not usability: the spec makes many fields nullable."""
+
+    def test_true_only_when_populated(self):
+        df = pd.DataFrame({"a": [1, None], "empty": [None, None]})
+
+        assert has_data(df, "a")
+        assert not has_data(df, "empty"), "present but all-null is not usable"
+        assert not has_data(df, "absent")
+        assert not has_data(df, "a", "empty"), "all named columns must be usable"
+
+    def test_false_for_empty_or_none_frame(self):
+        assert not has_data(None, "a")
+        assert not has_data(pd.DataFrame(), "a")
+
+
+class TestMassError:
+    @staticmethod
+    def _psm(with_column=False, n=200):
+        rng = np.random.default_rng(0)
+        calculated = pd.Series(np.linspace(400.0, 900.0, n))
+        # ~2 ppm systematic offset plus noise
+        observed = calculated * (1 + (2.0 + rng.normal(0, 0.5, n)) / 1e6)
+        df = pd.DataFrame(
+            {"calculated_mz": calculated, "observed_mz": observed, "charge": [2] * n}
+        )
+        df["mass_error_ppm"] = (
+            pd.Series(np.full(n, 5.0)) if with_column else pd.Series([None] * n)
+        )
+        return df
+
+    def test_derives_when_column_is_empty(self):
+        ppm, da, source = calculate_mass_error(self._psm())
+
+        assert source == "derived"
+        assert ppm is not None and da is not None
+        centre = max(ppm["count"], key=ppm["count"].get)
+        assert 1.0 < centre < 3.0, "derived ppm should centre near the 2 ppm offset"
+
+    def test_prefers_the_column_when_populated(self):
+        ppm, _, source = calculate_mass_error(self._psm(with_column=True))
+
+        assert source == "column"
+        assert ppm is None, "a constant column has no spread to bin"
+
+    def test_no_mz_and_no_column(self):
+        df = pd.DataFrame({"charge": [2, 3]})
+        assert calculate_mass_error(df) == (None, None, None)
+
+    def test_da_needs_charge(self):
+        df = self._psm().drop(columns=["charge"])
+        ppm, da, _ = calculate_mass_error(df)
+
+        assert ppm is not None
+        assert da is None, "Da conversion is impossible without charge"
+
+
+class TestOversampling:
+    def test_bins_precursor_repeat_counts(self):
+        df = pd.DataFrame(
+            {
+                "run": ["r1"] * 6,
+                # A seen 1x, B 2x, C 3x
+                "peptidoform": ["A", "B", "B", "C", "C", "C"],
+                "charge": [2, 2, 2, 2, 2, 2],
+            }
+        )
+        data, cats = calculate_oversampling(df)
+
+        assert set(cats) == {"1", "2", ">=3"}
+        assert data["r1"] == {"1": 1 / 3 * 100, "2": 1 / 3 * 100, ">=3": 1 / 3 * 100}
+
+    def test_skipped_without_required_columns(self):
+        assert calculate_oversampling(pd.DataFrame({"run": ["r1"]})) == (None, None)
+        assert calculate_oversampling(None) == (None, None)
+
+
+class TestContaminants:
+    @staticmethod
+    def _pg(contaminant):
+        return pd.DataFrame(
+            {
+                "run": ["r1", "r1"],
+                "anchor_protein": ["P1", "CONT_P2"],
+                "pg_accessions": [["P1"], ["CONT_P2"]],
+                "intensity": [900.0, 100.0],
+                "contaminant": contaminant,
+            }
+        )
+
+    def test_uses_the_flag(self):
+        per_run, top_n = calculate_contaminants(self._pg([False, True]), "CONT")
+
+        assert per_run["r1"]["Potential Contaminants"] == 10.0
+        assert top_n["r1"]["CONT_P2"] == 10.0
+
+    def test_all_null_flag_falls_back_to_the_affix(self):
+        """Null means unknown, so fall through rather than claiming 0%."""
+        per_run, _ = calculate_contaminants(self._pg([None, None]), "CONT")
+
+        assert per_run["r1"]["Potential Contaminants"] == 10.0
+
+    def test_all_null_and_no_affix_is_skipped(self):
+        assert calculate_contaminants(self._pg([None, None]), "") == (None, None)
+
+    def test_known_clean_is_skipped(self):
+        """Known-clean is a real answer, but an all-zero chart conveys nothing."""
+        assert calculate_contaminants(self._pg([False, False]), "CONT") == (None, None)
+
+    def test_partial_contamination_still_reports_top_n(self):
+        per_run, top_n = calculate_contaminants(self._pg([False, True]), "CONT")
+
+        assert per_run["r1"]["Potential Contaminants"] == 10.0
+        assert set(top_n["r1"]) == {"CONT_P2"}
+
+
+class TestSearchEngineScores:
+    def test_prefers_a_named_engine_score(self):
+        df = pd.DataFrame(
+            {
+                "run": ["r1"] * 4,
+                "additional_scores": [
+                    _scores(("andromeda_score", v), ("q-value", 0.01))
+                    for v in (10.0, 50.0, 120.0, 200.0)
+                ],
+                "posterior_error_probability": [0.1, 0.2, 0.3, 0.4],
+            }
+        )
+        _, name = calculate_search_engine_scores(df)
+        assert name == "andromeda_score"
+
+    def test_falls_back_to_pep_then_qvalue(self):
+        pep_only = pd.DataFrame(
+            {"run": ["r1"] * 4, "posterior_error_probability": [0.1, 0.2, 0.3, 0.4]}
+        )
+        _, name = calculate_search_engine_scores(pep_only)
+        assert name == "posterior_error_probability"
+
+        qvalue_only = pd.DataFrame(
+            {
+                "run": ["r1"] * 4,
+                "additional_scores": [_scores(("q-value", v)) for v in (0.001, 0.01, 0.02, 0.05)],
+            }
+        )
+        _, name = calculate_search_engine_scores(qvalue_only)
+        assert name == "q-value"
+
+    def test_bins_adapt_to_the_observed_range(self):
+        """A 0-1 PEP and a 0-300 engine score must not share fixed bins."""
+        small = pd.DataFrame(
+            {"run": ["r1"] * 50, "posterior_error_probability": np.linspace(0, 0.5, 50)}
+        )
+        large = pd.DataFrame(
+            {
+                "run": ["r1"] * 50,
+                "additional_scores": [_scores(("hyperscore", v)) for v in np.linspace(0, 300, 50)],
+            }
+        )
+        small_data, _ = calculate_search_engine_scores(small)
+        large_data, _ = calculate_search_engine_scores(large)
+
+        assert sum(small_data["r1"].values()) > 0
+        assert sum(large_data["r1"].values()) > 0
+        # Bin labels differ by orders of magnitude between the two.
+        assert list(small_data["r1"])[-1] != list(large_data["r1"])[-1]
+
+    def test_no_score_available(self):
+        assert calculate_search_engine_scores(pd.DataFrame({"run": ["r1"]})) == (None, None)
+
+    def test_constant_score_has_no_spread(self):
+        df = pd.DataFrame({"run": ["r1"] * 5, "posterior_error_probability": [0.1] * 5})
+        assert calculate_search_engine_scores(df) == (None, None)
+
+
+class TestProteinGroupKey:
+    def test_keys_on_the_accession_set_not_the_anchor(self):
+        """Two distinct groups may share an anchor; they must stay distinct."""
+        df = pd.DataFrame(
+            {
+                "anchor_protein": ["P1", "P1"],
+                "pg_accessions": [["P1", "P2"], ["P1", "P3"]],
+            }
+        )
+        keys = protein_group_key(df)
+
+        assert keys.nunique() == 2, "shared anchor must not collapse distinct groups"
+
+    def test_order_independent(self):
+        df = pd.DataFrame({"pg_accessions": [["P2", "P1"], ["P1", "P2"]]})
+        assert protein_group_key(df).nunique() == 1
+
+    def test_falls_back_to_anchor(self):
+        df = pd.DataFrame({"anchor_protein": ["P1", "P2"]})
+        assert protein_group_key(df).nunique() == 2
+
+
+class TestPca:
+    def test_returns_a_point_per_run(self):
+        rng = np.random.default_rng(1)
+        rows = []
+        for protein in range(30):
+            for run in ["r1", "r2", "r3"]:
+                rows.append(
+                    {
+                        "run": run,
+                        "pg_accessions": [f"P{protein}"],
+                        "intensity": float(rng.uniform(1e5, 1e7)),
+                    }
+                )
+        result = protein_intensity_pca(pd.DataFrame(rows))
+
+        assert set(result) == {"r1", "r2", "r3"}
+        assert all({"x", "y"} == set(v) for v in result.values())
+
+    def test_needs_at_least_two_runs(self):
+        df = pd.DataFrame(
+            {"run": ["r1"] * 3, "pg_accessions": [["P1"], ["P2"], ["P3"]],
+             "intensity": [1.0, 2.0, 3.0]}
+        )
+        assert protein_intensity_pca(df) is None
+
+
+class TestPeptideTableAndStd:
+    @staticmethod
+    def _feature():
+        return pd.DataFrame(
+            {
+                "run": ["r1", "r2", "r1", "r2"],
+                "peptidoform": ["A", "A", "B", "B"],
+                "charge": [2, 2, 3, 3],
+                "anchor_protein": ["P1", "P1", "P2", "P2"],
+                "intensities": [
+                    [{"label": "LFQ", "intensity": v}] for v in (100.0, 200.0, 300.0, 400.0)
+                ],
+            }
+        )
+
+    def test_peptide_table(self):
+        table, headers = create_qpx_peptide_table(self._feature(), pd.DataFrame(), pd.DataFrame())
+
+        rows = {e["PeptideID"]: e for e in table.values()}
+        assert set(rows) == {"A", "B"}
+        assert rows["A"]["Average Intensity"] == float(np.log10(150.0))
+        assert "Charge" in headers and "ProteinName" in headers
+
+    def test_peptide_table_without_intensities(self):
+        df = self._feature().drop(columns=["intensities"])
+        assert create_qpx_peptide_table(df, None, None) == (None, None)
+
+    def test_intensity_std_needs_a_design(self):
+        assert calculate_intensity_std(self._feature(), pd.DataFrame(), pd.DataFrame()) == {}
+
+    def test_intensity_std_per_condition(self):
+        sample_df = pd.DataFrame({"Sample": [1, 2], "Condition": ["A", "A"]})
+        file_df = pd.DataFrame({"Sample": [1, 2], "Run": ["r1", "r2"]})
+
+        result = calculate_intensity_std(self._feature(), sample_df, file_df)
+
+        assert set(result) == {"A"}
+        assert len(result["A"]) == 2, "one std per peptidoform"
+
+
+class TestContaminantsZeroSignal:
+    def test_all_zero_is_skipped_not_drawn(self):
+        """0% everywhere is a real answer, but an all-zero bar chart shows nothing."""
+        pg = pd.DataFrame(
+            {
+                "run": ["r1", "r2"],
+                "anchor_protein": ["P1", "P2"],
+                "pg_accessions": [["P1"], ["P2"]],
+                "intensity": [900.0, 100.0],
+                "contaminant": [False, False],
+            }
+        )
+        assert calculate_contaminants(pg, "CONT") == (None, None)


### PR DESCRIPTION
Makes the QPX module read the experimental design from the quantms.io parquet tables when no external design file is present.

> **Based on #697**, so it targets `fix/pr696-review-findings` rather than `dev`. Retarget to `dev` once #697 merges. The design-derivation commit is `60742e9`; everything before it belongs to #697.

## The problem

A quantms.io project is self-describing. `run.parquet` carries the run → sample mapping and `sample.parquet` the sample characteristics:

```
Run                                            Sample    Label  Fraction  BioRep
LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01   Sample 1  LFQ    1         1
LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02   Sample 1  LFQ    1         1
LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01   Sample 2  LFQ    1         1
...
```

The QPX module ignored both — `sample.parquet` was never read at all (no search pattern), and `run.parquet` was used only for the enzyme and the run-metadata table. `file_df` was built *only* from an external `exp_design`/`sdrf` file.

When a project ships without one, `file_df` stays empty and every sample-level consumer bails out early — `cal_num_table_at_sample` (`if file_df.empty: return dict()`), `_sample_level_mods`, `get_pep_intensity`, and `draw_exp_design` never runs. All of it silent: no error, exit 0, just a report missing its sample dimension.

## The change

When no external design file is found, reconstruct `(sample_df, file_df)` from the parquet tables in the same schema `read_openms_design` returns. **An external file still wins**, so existing projects are untouched.

- **`qpx_design.py`** (new) — `build_design_from_parquet()`.
  - `Sample` and `Label` are emitted as **integers**, because downstream does `file_df["Sample"].astype(int)`. Sample ids come from a trailing number in the accession when unique, else positional.
  - `Label` maps LFQ → 1 and TMT/iTRAQ channels → their channel number, matching the mapping `get_pep_intensity` already uses.
  - `Condition` comes from the sample characteristics that actually *vary*: one → used as-is (matching quantms, which puts e.g. `HCT 116` in `MSstats_Condition`); several → `key=value;key=value`, the multi-condition form `draw_exp_design` already parses. `sample_accession` is excluded, since it varies by definition.
  - Returns `(None, None)` when the tables can't supply a design, so the caller falls back rather than rendering a broken table.
- **`general.py`** — split `draw_exp_design` into a thin file-reading wrapper plus `draw_exp_design_tables()` that renders from already-parsed frames. No behavior change for existing callers.
- **`main.py`** — register the `pmultiqc/qpx_sample` search pattern.

## Verification

Two datasets, both run end-to-end:

**`qpx.zip` (openms, 307,905 PSMs, 6 runs, 2 samples, no design file)** — design derived, and the sample dimension comes back:

| Plot | Before | After |
|---|---|---|
| ProteinGroups Count | by Run, 6 bars | by Run, 6 bars **+ by Sample, 2 bars** |
| Peptide ID Count | by Run | by Run **+ by Sample** |
| Peptide Intensity Distribution | by Run, 6 boxes | by Run **+ by Sample, 2 boxes** |
| Modifications | by Sample label present but empty | by Sample **populated** |
| Experimental Design | absent | **present** |

Condition resolved to `12500 amol` / `125 amol` — `spiked_compound` is the only varying characteristic (cell line is K562 throughout), which is the actual UPS1 dilution series.

**`qpx_example.zip` (PXD012255, ships an openms design tsv)** — derivation correctly does not fire, and report data is **byte-identical** to #697. Regression check passed.

Both runs: exit 0, zero swallowed failures.

## Tests

`tests/test_qpx_design.py`, 18 tests — schema conformance, run→sample mapping, integer Sample/Label, TMT multiplexing, multi-fraction runs, all three Condition derivation paths, and four graceful-degradation cases (no run_df, empty, missing `samples` column, empty sample lists). Full suite 101 passed. Also re-run under `LC_ALL=C` (the ASCII locale that broke CI on #697). `flake8` diffed before/after: no new issues.


---

# QC HeatMap and protein-level quantification (`e0ba35c`)

QPX drew **no heatmap at all**, and its Quantification Analysis section held a single plot (peptide intensity) despite `pg.parquet` carrying an intensity and q-value per protein group.

## QC HeatMap

`qpx_heatmap.py`, using the same formulas as the quantms DDA heatmap so scores are comparable across report types, rendered through the existing `general.draw_heatmap`. All 8 metrics compute on both datasets:

| Run | Contam | Pep Int | Charge | MC | MC Var | ID/RT | OverSamp | Pep Missing |
|---|---|---|---|---|---|---|---|---|
| Cond_A_Sample_Alpha_01 | 1.0 | 1.0 | 0.989 | 0.448 | 0.999 | 0.505 | 0.842 | 0.584 |
| Cond_A_Sample_Alpha_02 | 1.0 | 1.0 | 0.988 | 0.445 | 0.999 | 0.505 | 0.841 | 0.584 |
| Cond_A_Sample_Alpha_03 | 1.0 | 1.0 | 0.981 | 0.442 | 0.995 | 0.499 | 0.835 | 0.601 |
| Cond_B_Sample_Alpha_01 | 1.0 | 1.0 | 0.977 | 0.448 | 0.998 | 0.507 | 0.840 | 0.590 |
| Cond_B_Sample_Alpha_02 | 1.0 | 1.0 | 0.985 | 0.451 | 0.996 | 0.503 | 0.832 | 0.572 |
| Cond_B_Sample_Alpha_03 | 1.0 | 1.0 | 0.989 | 0.442 | 0.995 | 0.500 | 0.832 | 0.609 |

**Every metric is optional.** One whose input column is absent or empty — or which covers only *some* runs — is dropped rather than padded with invented cells, and the omission is logged. This matters here: `psm.missed_cleavages`, `feature.unique`, `psm.mass_error_ppm` and `pg.sequence_coverage` are entirely null in both datasets, so metrics are computed from what is actually populated (missed cleavages still come from the enzyme rule, not the null column).

**The two saturated columns were verified against raw data rather than assumed:**
- Peptide Intensity = 1.0 is a legitimate clamp — median feature intensity is 6.0e7–8.7e7, i.e. **7–10x** the `2**23` reference quantms scales against.
- Contaminants = 1.0 is real — **no** protein group is contaminant-flagged in either dataset, so contaminant signal is genuinely 0%. (An earlier grep of mine appeared to find 652 contaminants; that was a case-insensitive artifact matching `ACON_YEAST`. There are none.)

It runs after the identification step to reuse the missed-cleavage counts computed there; `add_sub_section` still places it inside Results Overview by `order`.

## Protein quantification

`qpx_quant.py`:
- **Protein Quantification Table** — protein, distinct peptide count, log10 average intensity, best global q-value, plus a log10 average **per condition** when a design is available. Reuses `dia_utils.draw_protein_table` with a new `"qpx"` description branch. 6,926 groups on the openms dataset, 965 on PXD012255. The per-condition columns (`125 amol` / `12500 amol`) come from the design derived earlier in this PR.
- **Protein Intensity Distribution** — box plot by run and by sample, mirroring the peptide plot.

## Reader robustness

`qpx_io.py` now intersects requested columns with the file schema before reading — quantms.io writers vary by version and pyarrow *raises* on an absent column rather than ignoring it. That makes the newly-requested optional `contaminant` column safe to add, and guards decoy filtering on `is_decoy` actually being present. Verified `--remove-decoy` still filters (307,905 → 307,669 PSMs; 229,122 → 228,962 features).

## Tests

`tests/test_qpx_heatmap.py`, 22 tests — full metric set, metric-dropping when data is absent, **the partial-coverage case** (a metric covering only some runs is dropped, not padded), contaminant flag-vs-affix precedence, intensity scaling and clamping, oversampling and missing-value maths, protein table contents/sorting/condition columns, and protein intensity by run/sample.

Suite now **123 passed**, also green under `LC_ALL=C`. `flake8` diffed before/after: no new issues.


---

# Column-availability guarding (`d705ed6`)

Follow-up to the reader change above, closing a hole it opened.

Making `parse_qpx_parquet` request only columns present in the file schema means a loaded table can legitimately **lack** a column. The existing fixed selections then became a `KeyError` source:

```python
psm = self.psm_df[["run", "sequence", "charge", "modifications"]].copy()
#   KeyError: "['modifications'] not in index"  -> swallowed by _safe_draw
```

`_safe_draw` catches it, so the failure mode was an entire section silently disappearing — exactly the bug class this PR set out to fix. The old behaviour at least failed loudly at read time, so this was a net regression until guarded.

**Fix:** `qpx_io.select_columns(df, columns, context)` returns the sub-frame only when every column is present, else `None` plus a warning naming what is missing. Applied at the four parquet-derived selection sites (Identification Summary, Peptide Intensity, MS2 stats, RT QC). `calculate_run_stat` also tolerates a missing `modifications`.

**Verified** by rewriting the PXD012255 parquet files without `psm.modifications` and `feature.intensities`:

| | before guards | after guards |
|---|---|---|
| Tracebacks | 6 | **0** |
| Failed sections | 1 (Results Overview) | **0** |
| Diagnostics | none | 2 explicit skip warnings + heatmap omission notice |
| Sections rendered | — | 12, heatmap at 5 of 8 metrics |

On healthy data the guards are inert: both real datasets emit no skip/omission lines, all 8 heatmap metrics compute, and the matrix is **numerically identical** to the pre-guard measurement (row 1: `1.0, 1.0, 0.989, 0.448, 0.999, 0.505, 0.842, 0.584`).

Suite now **128 passed** (5 new guard tests), green under `LC_ALL=C`, no new flake8 issues.
