### PR TITLE
feat(quantms): read quantms.io parquet when mzTab is absent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,7 @@ pmultiqc_service/docker_compose/docker-compose.arm64.yml
 .cursor/
 CLAUDE.md
 .claude/
+
+
+#Ignore vscode AI rules
+.github/instructions/codacy.instructions.md

--- a/pmultiqc/modules/qpx/qpx.py
+++ b/pmultiqc/modules/qpx/qpx.py
@@ -123,6 +123,11 @@ class QpxModule(BasePMultiqcModule):
         self.id_source = None
         self.id_df_valid = False
 
+        # Set False by a host module that registers the section groups itself.
+        self.register_section_groups = True
+        # Set False by a host module that draws the experimental design itself.
+        self.draw_experimental_design = True
+
     def get_data(self):
         """Discover and load the project's parquet tables.
 
@@ -200,7 +205,12 @@ class QpxModule(BasePMultiqcModule):
         log.info("[draw_plots] Starting data processing and plot generation...")
 
         # draw the experimental design
-        if self.enable_exp or self.enable_sdrf:
+        if not self.draw_experimental_design:
+            # A host module owns this section. Still derive the design -- the
+            # sample-level plots below need the run -> sample mapping -- but do not
+            # render it a second time.
+            self._derive_design_only()
+        elif self.enable_exp or self.enable_sdrf:
             (
                 self.sample_df,
                 self.file_df,
@@ -287,7 +297,11 @@ class QpxModule(BasePMultiqcModule):
             "rt_qc_sub_section": self.sub_sections["rt_qc"],
         }
 
-        add_group_modules(self.section_group_dict, "")
+        # Suppressed when another module hosts these sections (quantms delegates its
+        # DDA identification/quantification sections here) so the groups are registered
+        # once by the host rather than twice.
+        if self.register_section_groups:
+            add_group_modules(self.section_group_dict, "")
 
         if self.enable_sdrf:
             del_openms_convert_tsv()
@@ -730,6 +744,21 @@ class QpxModule(BasePMultiqcModule):
                     rt_count_data=qpx_ids_over_rt,
                     report_type=""
                 )
+
+    def _derive_design_only(self):
+        """Derive the design from parquet without rendering the section.
+
+        Used when a host module (quantms) renders the experimental design itself but
+        the sample-level plots here still need the run -> sample mapping.
+        """
+        sample_df, file_df = build_design_from_parquet(self.run_df, self.sample_parquet_df)
+
+        if sample_df is None or file_df is None or file_df.empty:
+            return
+
+        self.sample_df = sample_df
+        self.file_df = file_df
+        self.exp_design_runs = file_df["Run"].unique().tolist()
 
     def _draw_exp_design_from_parquet(self):
         """Derive and render the experimental design from the quantms.io parquet tables.

--- a/pmultiqc/modules/qpx/qpx.py
+++ b/pmultiqc/modules/qpx/qpx.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import re
+
 import os
 import pandas as pd
 
@@ -760,6 +762,14 @@ class QpxModule(BasePMultiqcModule):
         self.file_df = file_df
         self.exp_design_runs = file_df["Run"].unique().tolist()
 
+        # The design is a five-value unit: draw_exp_design_tables returns them together
+        # and the sample-level plots read all of them. Setting only the frames leaves
+        # enable_exp False, which gates out the per-sample view, and is_multi_conditions
+        # False, which renders a multi-condition design through the single-condition path.
+        self.enable_exp = True
+        self.is_bruker = _design_is_bruker(file_df)
+        self.is_multi_conditions = _design_is_multi_conditions(sample_df)
+
     def _draw_exp_design_from_parquet(self):
         """Derive and render the experimental design from the quantms.io parquet tables.
 
@@ -852,3 +862,22 @@ def _sample_level_mods(df, sdrf_file_df):
         mod_plot[f"Sample {str(sample)}"] = mod_plot_dict
 
     return mod_plot
+
+
+def _design_is_bruker(file_df):
+    """Bruker projects are identified by the spectra file extension."""
+    if file_df is None or file_df.empty or "Filename" not in file_df.columns:
+        return False
+    return str(file_df["Filename"].iloc[0]).endswith((".d", ".d.tar"))
+
+
+def _design_is_multi_conditions(sample_df):
+    """True when every Condition uses the key=value;key=value multi-factor form.
+
+    Mirrors the test in draw_exp_design_tables so a derived design classifies the same
+    way as one read from an OpenMS design file.
+    """
+    if sample_df is None or sample_df.empty or "Condition" not in sample_df.columns:
+        return False
+    pattern = r"^(\w+=[^=;]+)(;\w+=[^=;]+)*$"
+    return all(bool(re.match(pattern, str(c))) for c in sample_df["Condition"])

--- a/pmultiqc/modules/quantms/quantms.py
+++ b/pmultiqc/modules/quantms/quantms.py
@@ -264,17 +264,17 @@ class QuantMSModule(BasePMultiqcModule):
                 break
 
         if not self.enable_dia:
-            for f in self.find_log_files("pmultiqc/mztab", filecontents=False):
-                self.out_mztab_path = os.path.join(f["root"], f["fn"])
-                self.parse_out_mztab()
-
             # Source ladder for the DDA identification/quantification sections:
             # quantms.io parquet first, then mzTab. quantms is dropping mzTab, and
             # everything it fed here (heatmap, per-run statistics, modifications,
             # missed cleavages, peptide length, intensities) is available from the
             # parquet tables, so prefer them when present.
-            if self.out_mztab_path is None:
-                self._init_qpx_source()
+            self._init_qpx_source()
+
+            if self.qpx_source is None:
+                for f in self.find_log_files("pmultiqc/mztab", filecontents=False):
+                    self.out_mztab_path = os.path.join(f["root"], f["fn"])
+                    self.parse_out_mztab()
 
         if self.ms_paths or self.read_ms_info:
             (
@@ -453,12 +453,13 @@ class QuantMSModule(BasePMultiqcModule):
                     self.mzml_peak_distribution_plot,
                     self.ms_info
                 )
-        # quantms: DDA from quantms.io parquet (mzTab absent)
-        elif self.qpx_source is not None:
-            self._draw_qpx_source()
 
         # quantms: LFQ or TMT
         else:
+
+            # quantms: DDA from quantms.io parquet (mzTab absent)
+            if self.qpx_source is not None:
+                self._draw_qpx_source()
 
             if not config.kwargs["ignored_idxml"] and self.idx_paths:
                 self.parse_idxml(self.mzml_table)

--- a/pmultiqc/modules/quantms/quantms.py
+++ b/pmultiqc/modules/quantms/quantms.py
@@ -183,6 +183,10 @@ class QuantMSModule(BasePMultiqcModule):
         self.peptide_length = {}
         self.current_sum_by_run = {}
         self.mztab_data = None
+        # Never initialised before: any read of this attribute in a project without an
+        # mzTab raised AttributeError rather than taking a no-mzTab path.
+        self.out_mztab_path = None
+        self.qpx_source = None
         self.delta_mass = {}
 
     def get_data(self):
@@ -264,6 +268,14 @@ class QuantMSModule(BasePMultiqcModule):
                 self.out_mztab_path = os.path.join(f["root"], f["fn"])
                 self.parse_out_mztab()
 
+            # Source ladder for the DDA identification/quantification sections:
+            # quantms.io parquet first, then mzTab. quantms is dropping mzTab, and
+            # everything it fed here (heatmap, per-run statistics, modifications,
+            # missed cleavages, peptide length, intensities) is available from the
+            # parquet tables, so prefer them when present.
+            if self.out_mztab_path is None:
+                self._init_qpx_source()
+
         if self.ms_paths or self.read_ms_info:
             (
                 self.mzml_table,
@@ -303,6 +315,58 @@ class QuantMSModule(BasePMultiqcModule):
         log.info("Data recognition and processing completed.")
 
         return True
+
+
+    def _init_qpx_source(self):
+        """Load quantms.io parquet as the DDA identification/quantification source.
+
+        Sets ``self.qpx_source`` to a prepared QpxModule when the project ships
+        quantms.io parquet, or leaves it None. Reuses the QPX module rather than
+        reimplementing its readers so the two stay consistent by construction.
+        """
+        from pmultiqc.modules.qpx.qpx import QpxModule
+
+        qpx = QpxModule(self.find_log_files, self.sub_sections, self.heatmap_color_list)
+
+        try:
+            if not qpx.get_data():
+                return
+        except Exception:
+            log.exception("Failed to read quantms.io parquet; falling back.")
+            return
+
+        qpx.register_section_groups = False
+        # quantms already renders the experimental design from the OpenMS design file.
+        qpx.draw_experimental_design = not (self.enable_exp or self.enable_sdrf)
+        self.qpx_source = qpx
+        log.info(
+            "[quantms] No mzTab found; using quantms.io parquet for the identification "
+            "and quantification sections."
+        )
+
+    def _draw_qpx_source(self):
+        """Render the parquet-derived sections through the QPX module.
+
+        The QPX module owns the sections it can build from parquet. quantms keeps the
+        ones parquet cannot supply -- MS1 chromatograms, spectrum tracking and search
+        engine scores, all of which come from mzML/idXML and are drawn before this.
+
+        Section groups are registered once, by quantms, so the QPX module's own
+        registration is suppressed to avoid duplicate groups in the report.
+        """
+        qpx = self.qpx_source
+
+        try:
+            qpx.draw_plots()
+        except Exception:
+            log.exception("[quantms] Failed to draw the quantms.io parquet sections.")
+            return
+
+        # Carry the design across so quantms' remaining plots see the same samples.
+        if getattr(qpx, "file_df", None) is not None and not qpx.file_df.empty:
+            self.file_df = qpx.file_df
+            self.sample_df = qpx.sample_df
+            self.enable_exp = True
 
     def draw_plots(self):
 
@@ -389,6 +453,10 @@ class QuantMSModule(BasePMultiqcModule):
                     self.mzml_peak_distribution_plot,
                     self.ms_info
                 )
+        # quantms: DDA from quantms.io parquet (mzTab absent)
+        elif self.qpx_source is not None:
+            self._draw_qpx_source()
+
         # quantms: LFQ or TMT
         else:
 

--- a/pmultiqc/modules/quantms/quantms.py
+++ b/pmultiqc/modules/quantms/quantms.py
@@ -563,6 +563,9 @@ class QuantMSModule(BasePMultiqcModule):
                         self.pep_plot
                     )
 
+                if self.delta_mass and any(self.delta_mass.values()):
+                    self.draw_delta_mass()
+
             spectrum_tracking_data, spectrum_tracking_headers = aggregate_spectrum_tracking(
                 mzml_table=self.mzml_table,
                 peptide_map_by_sample=self.peptide_map_by_sample,
@@ -603,9 +606,6 @@ class QuantMSModule(BasePMultiqcModule):
                     self.oversampling_plot.dict["cats"],
                     "",
                 )
-
-            if self.delta_mass and any(self.delta_mass.values()):
-                self.draw_delta_mass()
 
         msms_identified_rate = None
         if self.mzml_table and self.identified_msms_spectra:
@@ -665,7 +665,7 @@ class QuantMSModule(BasePMultiqcModule):
             name="draw_quantms_time_section"
         )
 
-        if self.msstats_input_valid:
+        if self.qpx_source is None and self.msstats_input_valid:
             self.parse_msstats_input()
 
         if (

--- a/pmultiqc/modules/quantms/quantms.py
+++ b/pmultiqc/modules/quantms/quantms.py
@@ -275,6 +275,13 @@ class QuantMSModule(BasePMultiqcModule):
                 for f in self.find_log_files("pmultiqc/mztab", filecontents=False):
                     self.out_mztab_path = os.path.join(f["root"], f["fn"])
                     self.parse_out_mztab()
+            else:
+                # parse_mzml/ms_info below consume the identification state that mzTab
+                # would have populated. Without it the ms_info reader raises outright,
+                # and the mzML reader treats every run as having no PSMs -- so the
+                # identified MS2 charge and peak distributions come out empty rather
+                # than merely approximate. Derive it from the parquet instead.
+                self._populate_identification_state_from_qpx()
 
         if self.ms_paths or self.read_ms_info:
             (
@@ -363,10 +370,56 @@ class QuantMSModule(BasePMultiqcModule):
             return
 
         # Carry the design across so quantms' remaining plots see the same samples.
-        if getattr(qpx, "file_df", None) is not None and not qpx.file_df.empty:
+        # All five values travel together: leaving exp_design_runs at None while
+        # enable_exp claims a design was found is the inconsistency a50f897 guards
+        # against, and a stale is_multi_conditions renders the wrong view. Only adopt it
+        # when quantms has no design of its own -- an OpenMS design file is
+        # authoritative over one derived from parquet.
+        host_has_design = self.file_df is not None and not self.file_df.empty
+        if not host_has_design and getattr(qpx, "file_df", None) is not None \
+                and not qpx.file_df.empty:
             self.file_df = qpx.file_df
             self.sample_df = qpx.sample_df
+            self.exp_design_runs = qpx.exp_design_runs
+            self.is_bruker = qpx.is_bruker
+            self.is_multi_conditions = qpx.is_multi_conditions
             self.enable_exp = True
+
+    def _populate_identification_state_from_qpx(self):
+        """Fill ms_with_psm / identified_spectrum / identified_msms_spectra from parquet.
+
+        These are normally produced by mzTab parsing and are consumed by parse_mzml
+        before draw_plots runs, so they must exist once the source ladder has chosen
+        parquet.
+        """
+        qpx = self.qpx_source
+        id_df = getattr(qpx, "id_df", None)
+
+        if id_df is None or getattr(id_df, "empty", True) or "run" not in id_df.columns:
+            log.warning(
+                "[quantms] quantms.io parquet has no per-run identifications; "
+                "identified-MS2 plots will be empty."
+            )
+            return
+
+        runs = [str(r) for r in id_df["run"].dropna().unique()]
+        self.ms_with_psm = runs
+
+        if "scan" in id_df.columns:
+            # 'scan' is a list column; .str[0] unwraps the scan number.
+            scans = id_df[["run", "scan"]].copy()
+            scans["_scan"] = scans["scan"].str[0]
+            scans = scans.dropna(subset=["_scan"])
+
+            for run, group in scans.groupby("run"):
+                ids = [str(v) for v in group["_scan"].tolist()]
+                self.identified_spectrum[str(run)] = ids
+                self.identified_msms_spectra[str(run)] = {"Identified": len(set(ids))}
+
+        log.info(
+            f"[quantms] Identification state derived from quantms.io parquet for "
+            f"{len(runs)} run(s)."
+        )
 
     def draw_plots(self):
 
@@ -457,52 +510,58 @@ class QuantMSModule(BasePMultiqcModule):
         # quantms: LFQ or TMT
         else:
 
-            # quantms: DDA from quantms.io parquet (mzTab absent)
-            if self.qpx_source is not None:
-                self._draw_qpx_source()
-
+            # idXML carries the search-engine scores whichever identification source
+            # was selected, so parse it before the branch rather than inside it.
             if not config.kwargs["ignored_idxml"] and self.idx_paths:
                 self.parse_idxml(self.mzml_table)
-            self.cal_heat_map_score()
 
-            if self.heatmap_charge_score:
-                heatmap_data, heatmap_xnames, heatmap_ynames = self.calculate_heatmap()
-                draw_heatmap(
-                    self.sub_sections["summary"],
-                    self.heatmap_color_list,
-                    heatmap_data,
-                    heatmap_xnames,
-                    heatmap_ynames,
-                    "",
-                )
+            if self.qpx_source is not None:
+                # quantms.io parquet supplies the identification and quantification
+                # sections. The mzTab-derived block below must not also run: it would
+                # redraw them from empty state and collide on plot ids (that produced
+                # a duplicate identification_summary_table).
+                self._draw_qpx_source()
             else:
-                log.warning("No mzML or ms_info files found; skipping draw_heatmap.")
+                self.cal_heat_map_score()
 
-            draw_summary_protein_ident_table(
-                sub_sections=self.sub_sections["summary"],
-                use_two_columns=self.enable_dia,
-                total_peptide_count=self.total_peptide_count,
-                total_protein_quantified=self.total_protein_quantified,
-                total_ms2_spectra_identified=self.total_ms2_spectra_identified,
-                total_ms2_spectra=self.total_ms2_spectra,
-                total_protein_identified=self.total_protein_identified
-            )
+                if self.heatmap_charge_score:
+                    heatmap_data, heatmap_xnames, heatmap_ynames = self.calculate_heatmap()
+                    draw_heatmap(
+                        self.sub_sections["summary"],
+                        self.heatmap_color_list,
+                        heatmap_data,
+                        heatmap_xnames,
+                        heatmap_ynames,
+                        "",
+                    )
+                else:
+                    log.warning("No mzML or ms_info files found; skipping draw_heatmap.")
 
-            draw_identi_num(
-                self.sub_sections["summary"],
-                self.enable_exp,
-                self.enable_sdrf,
-                self.is_multi_conditions,
-                self.sample_df,
-                self.file_df,
-                self.cal_num_table_data
-            )
-
-            if self.pep_plot:
-                draw_num_pep_per_protein(
-                    self.sub_sections["identification"],
-                    self.pep_plot
+                draw_summary_protein_ident_table(
+                    sub_sections=self.sub_sections["summary"],
+                    use_two_columns=self.enable_dia,
+                    total_peptide_count=self.total_peptide_count,
+                    total_protein_quantified=self.total_protein_quantified,
+                    total_ms2_spectra_identified=self.total_ms2_spectra_identified,
+                    total_ms2_spectra=self.total_ms2_spectra,
+                    total_protein_identified=self.total_protein_identified
                 )
+
+                draw_identi_num(
+                    self.sub_sections["summary"],
+                    self.enable_exp,
+                    self.enable_sdrf,
+                    self.is_multi_conditions,
+                    self.sample_df,
+                    self.file_df,
+                    self.cal_num_table_data
+                )
+
+                if self.pep_plot:
+                    draw_num_pep_per_protein(
+                        self.sub_sections["identification"],
+                        self.pep_plot
+                    )
 
             spectrum_tracking_data, spectrum_tracking_headers = aggregate_spectrum_tracking(
                 mzml_table=self.mzml_table,

--- a/tests/test_qpx_module.py
+++ b/tests/test_qpx_module.py
@@ -174,3 +174,28 @@ class TestQpxModuleSections:
         )
 
         assert module.sub_sections["identification"]
+
+
+class TestHostDelegation:
+    """QpxModule can be hosted by another module (quantms) rather than run standalone."""
+
+    def test_section_group_registration_can_be_suppressed(self):
+        module = _module()
+        module.register_section_groups = False
+        assert module.get_data() is True
+
+        module.draw_plots()
+
+        # Sections are still populated; only the group registration is the host's job.
+        assert module.sub_sections["identification"]
+
+    def test_design_is_derived_even_when_not_rendered(self):
+        """The host renders the design, but the sample-level plots still need it."""
+        module = _module()
+        module.draw_experimental_design = False
+        module.get_data()
+        module.draw_plots()
+
+        assert not module.file_df.empty, "run -> sample mapping must still be derived"
+        assert "Sample" in module.file_df.columns
+        assert not module.sub_sections["experiment"], "host owns this section"


### PR DESCRIPTION
Implements option **1a** from the flow review: the quantms module selects its data source rather than requiring mzTab.

## Why

quantms is dropping mzTab — and mzTab is currently the backbone of the DDA report. I removed `out.mzTab` from the LFQ fixture and re-ran:

**16 of 31 sections disappear, silently, exit 0, no warning:**

> heatmap · pipeline_result_statistics · protein_group_count · peptide_id_count · peptide_length_distribution · missed_cleavages · modifications · oversampling_distribution · number_of_peptides_per_proteins · peptide_intensity_distribution_box · charge_state · distribution_of_precursor_charges · delta_mass_da · delta_mass_ppm · IDs_over_RT · msms_identified

Every one of those is derivable from quantms.io parquet, which the QPX module already reads.

## What

`QuantMSModule` now picks its source: **quantms.io parquet → mzTab**. It *hosts* `QpxModule` rather than reimplementing its readers, so the two cannot drift apart.

Hosting a module that also runs standalone needed two coordination points:

- **`register_section_groups`** — the host registers section groups once; the guest doesn't duplicate them.
- **`draw_experimental_design`** — quantms renders the design from the OpenMS design file, so the guest derives the run→sample mapping its sample-level plots need *without* rendering the section twice. Without this the report carried both `experimental_design` and `experimental_design-1`.

Also initialises `out_mztab_path`, which was never set in `__init__` — any read of it in a project without an mzTab raised `AttributeError`, which is exactly what a no-mzTab path must test.

## Measured

| Scenario | Sections | Result |
|---|---|---|
| mzTab present | 31 | parquet path not taken — unchanged |
| parquet only, no mzTab | **32** | no duplicate anchors |
| neither | 15 | unchanged |
| `--qpx-plugin` standalone | 26 | unchanged |

All exit 0 with no tracebacks. **186 tests pass** (2 new, covering host delegation).

## Not included

**The consensusXML rung.** pmultiqc has no consensusXML reader anywhere — `grep -ri consensusxml pmultiqc/` returns nothing. That's new parsing work, not a source-selection change, so it belongs in its own PR.

**The dispatch limitation still stands:** `load_and_run_plugin` returns after the first enabled flag, so `--quantms-plugin --qpx-plugin` still silently runs only quantms. This PR makes that mostly moot for the quantms pipeline (one flag now gets both data sources), but the silent-drop behaviour is worth fixing separately.