### PR TITLE
Fix qpx example URL in CI and documentation

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -366,7 +366,9 @@ jobs:
         run: pip install .
       - name: Test qpx dataset
         run: |
-          wget -nv https://ftp.pride.ebi.ac.uk/pub/databases/pride/resources/proteomes/pmultiqc/example-projects/qpx_example.zip
+          # Hosted as a GitHub release attachment: the PRIDE copy of this file
+          # returns 404 (other PRIDE assets used by this workflow are unaffected).
+          wget -nv -O qpx_example.zip https://github.com/user-attachments/files/31028778/qpx_example.zip
           unzip -d ./qpx_example qpx_example.zip
           multiqc --qpx-plugin ./qpx_example --config ./qpx_example/results/multiqc_config.yml -o ./results_qpx
       - uses: actions/upload-artifact@v4

--- a/docs/README.md
+++ b/docs/README.md
@@ -270,7 +270,7 @@ You can find example reports on the [docs page](https://bigbio.github.io/pmultiq
 | mzIdentML with MGF | mzIdentML with MGF files | [mzIdentML with MGF Example](https://pmultiqc.quantms.org/PXD054720/multiqc_report.html) ([disable_hoverinfo](https://pmultiqc.quantms.org/PXD054720_disable_hoverinfo/multiqc_report.html)) | [PXD054720 folder](https://ftp.pride.ebi.ac.uk/pride/data/archive/2024/08/PXD054720/) |
 | FragPipe | FragPipe results | [FragPipe Example](https://pmultiqc.quantms.org/PXD062399/multiqc_report.html) ([disable_hoverinfo](https://pmultiqc.quantms.org/PXD062399_disable_hoverinfo/multiqc_report.html)) | [PXD062399.zip](https://ftp.pride.ebi.ac.uk/pub/databases/pride/resources/proteomes/pmultiqc/example-projects/PXD062399.zip) |
 | mhcquant | mhcquant results | [mhcquant Example](https://pmultiqc.quantms.org/mhcquant/multiqc_report.html) ([disable_hoverinfo](https://pmultiqc.quantms.org/mhcquant_disable_hoverinfo/multiqc_report.html)) | [mhcquant_3-1-0_results.zip](https://ftp.pride.ebi.ac.uk/pub/databases/pride/resources/proteomes/pmultiqc/mhcquant/mhcquant_3-1-0_results.zip) |
-| QPX | QPX results | [QPX Example](https://pmultiqc.quantms.org/qpx/multiqc_report.html) ([disable_hoverinfo](https://pmultiqc.quantms.org/qpx_disable_hoverinfo/multiqc_report.html)) | [qpx_example.zip](https://ftp.pride.ebi.ac.uk/pub/databases/pride/resources/proteomes/pmultiqc/example-projects/qpx_example.zip) |
+| QPX | QPX results | [QPX Example](https://pmultiqc.quantms.org/qpx/multiqc_report.html) ([disable_hoverinfo](https://pmultiqc.quantms.org/qpx_disable_hoverinfo/multiqc_report.html)) | [qpx_example.zip](https://github.com/user-attachments/files/31028778/qpx_example.zip) |
 
 ### 🔍 Large-Scale Dataset Reports
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -231,7 +231,7 @@
         {
             "accession": "qpx",
             "urls": [
-                "https://ftp.pride.ebi.ac.uk/pub/databases/pride/resources/proteomes/pmultiqc/example-projects/qpx_example.zip"
+                "https://github.com/user-attachments/files/31028778/qpx_example.zip"
             ],
             "path": "docs/qpx",
             "file_type": ["qpx", ""]
@@ -239,7 +239,7 @@
         {
             "accession": "qpx_disable_hoverinfo",
             "urls": [
-                "https://ftp.pride.ebi.ac.uk/pub/databases/pride/resources/proteomes/pmultiqc/example-projects/qpx_example.zip"
+                "https://github.com/user-attachments/files/31028778/qpx_example.zip"
             ],
             "path": "docs/qpx_disable_hoverinfo",
             "file_type": ["qpx", "disable_hoverinfo"]

--- a/docs/update_examples.py
+++ b/docs/update_examples.py
@@ -26,8 +26,13 @@ def download_file(url, save_path, max_retries=3, backoff_factor=2):
     ftp_host = ftp_parsed.hostname
     ftp_path = ftp_parsed.path
 
+    # Only hosts that actually serve FTP are worth trying. Without this, an HTTPS-only
+    # host (e.g. a GitHub-hosted asset) burns three connection timeouts plus backoff
+    # before reaching the HTTPS path that was always going to be the working one.
+    ftp_available = bool(ftp_host) and ftp_host.startswith("ftp.")
+
     # -------- Try FTP first --------
-    for attempt in range(1, max_retries + 1):
+    for attempt in range(1, max_retries + 1 if ftp_available else 1):
         try:
             print(f"[Attempt {attempt}] Trying FTP download: {ftp_host}{ftp_path}")
             ftp = FTP(ftp_host, timeout=30)


### PR DESCRIPTION
# Pull Request

## Description

Brief description of the changes made in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test addition/update
- [ ] Updates to the dependencies has been done. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved example dataset downloads by starting HTTPS fallback immediately for non-FTP hosts.
  * Updated automated example-data retrieval to use a more reliable hosted archive.

* **Documentation**
  * Updated QPX example download links across the documentation and example configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->