### PR TITLE
ci: update the PyPI publish action so it accepts our wheel metadata

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,7 +36,13 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      # v1.14.2. The previous pin was v1.4.2, whose bundled twine predates
+      # Metadata-Version 2.4/2.5 and rejected our wheel outright:
+      #   InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid
+      #   metadata version
+      # hatchling emits Metadata-Version 2.5, so the artifact is fine -- twine 7.0.0
+      # accepts it. Only the publisher was out of date.
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
The release job fails at the publish step:

```
Checking dist/pmultiqc-0.0.47-py3-none-any.whl: ERROR
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

## The wheel is not at fault

`hatchling` emits `Metadata-Version: 2.5`, which is current and correct. Reproduced locally with `python -m build`:

```
Metadata-Version: 2.5
Name: pmultiqc
Version: 0.0.47.dev44
```

And `twine check` on that exact artifact passes under twine 7.0.0:

```
Checking pmultiqc-...-py3-none-any.whl: PASSED
Checking pmultiqc-....tar.gz: PASSED
```

## The publisher is out of date

The pinned SHA `27b31702a0e7fc50959f5ad993c78deac1bdfc29` resolves to **v1.4.2**, released in 2021. Its bundled twine predates `Metadata-Version` 2.4/2.5 support, so it rejects a valid wheel.

Repointed at `dc37677b2e1c63e2034f94d8a5b11f265b73ba33` — **v1.14.2**, the current release — keeping a SHA pin rather than a moving tag, consistent with how the job was already written.

v1.14.2 still accepts the existing `user`/`password` inputs (they are retained as deprecated aliases of `verify-metadata` etc.), so nothing else in the job changes.

## Worth considering separately

v1.14.2 supports **Trusted Publishing** via OIDC, which removes the need for the `PYPI_API_TOKEN` secret entirely. That is a better long-term posture, but it needs configuration on the PyPI side, so I have not changed the auth mechanism here.