### PR TITLE
ci: update the PyPI publish action so it accepts our wheel metadata

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,7 +36,13 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      # v1.14.2. The previous pin was v1.4.2, whose bundled twine predates
+      # Metadata-Version 2.4/2.5 and rejected our wheel outright:
+      #   InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid
+      #   metadata version
+      # hatchling emits Metadata-Version 2.5, so the artifact is fine -- twine 7.0.0
+      # accepts it. Only the publisher was out of date.
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
The release job failed with:

  InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid
  metadata version

The wheel is not at fault. hatchling emits Metadata-Version 2.5, which is current and correct; twine 7.0.0 checks the exact artifact and passes both the wheel and the sdist. The problem is the publisher: the pinned SHA 27b31702a0e7fc50959f5ad993c78deac1bdfc29 is v1.4.2, released in 2021, and its bundled twine predates Metadata-Version 2.4/2.5 support.

Repointed at dc37677b2e1c63e2034f94d8a5b11f265b73ba33 (v1.14.2, the current release), keeping the SHA pin rather than a moving tag. v1.14.2 still accepts the existing user/password inputs, so nothing else in the job changes.

Reproduced locally with python -m build: the wheel carries Metadata-Version 2.5, and `twine check` on it passes under twine 7.0.0.

# Pull Request

## Description

Brief description of the changes made in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test addition/update
- [ ] Updates to the dependencies has been done. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing workflow to support newer Python package metadata formats.
  * Improved publishing compatibility and documented the related compatibility considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->