### PR TITLE
fix(dia): stop copying the whole DIA-NN report in the intensity and RT-QC plots

### DIFF
--- a/pmultiqc/modules/common/dia_utils.py
+++ b/pmultiqc/modules/common/dia_utils.py
@@ -367,7 +367,16 @@ def _get_peptide_length(df):
 
 
 def draw_dia_intensitys(sub_section, report_df, sdrf_file_df):
-    df_sub = report_df[report_df["Precursor.Quantity"] > 0].copy()
+    # Both consumers below only ever read these columns, so narrow the frame before
+    # copying it. Copying the full report here materialises every column (including
+    # the wide object-dtype string columns) for every row, which is what makes this
+    # step run out of memory on experiments with thousands of runs.
+    keep_cols = [
+        col
+        for col in ("Run", "Modified.Sequence", "Protein.Group", "Precursor.Quantity")
+        if col in report_df.columns
+    ]
+    df_sub = report_df.loc[report_df["Precursor.Quantity"] > 0, keep_cols].copy()
     df_sub["log_intensity"] = np.log2(df_sub["Precursor.Quantity"])
 
     dia_plots.draw_dia_intensity_dis(sub_section, df_sub, sdrf_file_df)
@@ -400,8 +409,26 @@ def draw_dia_mass_error(sub_section, df):
 
 
 # DIA-NN: RT Quality Control
+# Columns read by draw_dia_rt_qc and the helpers it calls. Anything else in the
+# DIA-NN report is irrelevant here and must not be carried into the local copy.
+RT_QC_COLUMNS = (
+    "Run",
+    "RT",
+    "Normalisation.Factor",
+    "FWHM",
+    "RT.Start",
+    "RT.Stop",
+    "Predicted.RT",
+    "iRT",
+)
+
+
 def draw_dia_rt_qc(sub_section, report_df):
-    df = report_df.copy()
+    # This function adds derived columns ("peak_width", "rt_error"), so it needs its
+    # own copy — but only of the columns it actually uses. Copying the whole report
+    # is what makes this step scale with report width as well as length.
+    keep_cols = [col for col in RT_QC_COLUMNS if col in report_df.columns]
+    df = report_df[keep_cols].copy()
 
     # IDs over RT
     draw_dia_ids_rt(sub_section, df)

--- a/pmultiqc/modules/common/dia_utils.py
+++ b/pmultiqc/modules/common/dia_utils.py
@@ -367,6 +367,7 @@ def _get_peptide_length(df):
 
 
 def draw_dia_intensitys(sub_section, report_df, sdrf_file_df):
+    """Draw the precursor intensity distribution and standard-deviation plots."""
     # Both consumers below only ever read these columns, so narrow the frame before
     # copying it. Copying the full report here materialises every column (including
     # the wide object-dtype string columns) for every row, which is what makes this
@@ -424,6 +425,7 @@ RT_QC_COLUMNS = (
 
 
 def draw_dia_rt_qc(sub_section, report_df):
+    """Draw the retention-time quality-control plots."""
     # This function adds derived columns ("peak_width", "rt_error"), so it needs its
     # own copy — but only of the columns it actually uses. Copying the whole report
     # is what makes this step scale with report width as well as length.

--- a/tests/test_diann.py
+++ b/tests/test_diann.py
@@ -3,8 +3,10 @@
 import os
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
+from pmultiqc.modules.common import dia_utils
 from pmultiqc.modules.common.dia_utils import parse_diann_version
 
 TEST_DATA_DIR = Path(os.path.dirname(__file__)) / "resources" / "diann"
@@ -56,8 +58,6 @@ class TestDiaReportMemory:
     @staticmethod
     def _report_df():
         """A DIA-NN-shaped report with extra columns none of these plots use."""
-        import pandas as pd
-
         return pd.DataFrame(
             {
                 "Run": ["run1", "run1", "run2", "run2"],
@@ -80,9 +80,6 @@ class TestDiaReportMemory:
 
     def test_draw_dia_intensitys_narrows_columns(self, monkeypatch):
         """Only Run/Modified.Sequence/Protein.Group/intensity reach the plots."""
-        from pmultiqc.modules.common import dia_utils
-        import pandas as pd
-
         captured = []
 
         def capture(sub_section, df, sdrf_file_df):
@@ -109,15 +106,8 @@ class TestDiaReportMemory:
 
     def test_draw_dia_intensitys_does_not_mutate_report(self, monkeypatch):
         """The caller's report must not gain a log_intensity column."""
-        from pmultiqc.modules.common import dia_utils
-        import pandas as pd
-
-        monkeypatch.setattr(
-            dia_utils.dia_plots, "draw_dia_intensity_dis", lambda *a, **k: None
-        )
-        monkeypatch.setattr(
-            dia_utils.dia_plots, "draw_dia_intensity_std", lambda *a, **k: None
-        )
+        monkeypatch.setattr(dia_utils.dia_plots, "draw_dia_intensity_dis", lambda *a, **k: None)
+        monkeypatch.setattr(dia_utils.dia_plots, "draw_dia_intensity_std", lambda *a, **k: None)
 
         report_df = self._report_df()
         before = list(report_df.columns)
@@ -128,8 +118,6 @@ class TestDiaReportMemory:
 
     def test_draw_dia_rt_qc_narrows_columns(self, monkeypatch):
         """RT QC copies only the RT-related columns, not the whole report."""
-        from pmultiqc.modules.common import dia_utils
-
         captured = []
 
         def capture_ids_rt(sub_section, report_df):
@@ -150,8 +138,6 @@ class TestDiaReportMemory:
 
     def test_draw_dia_rt_qc_tolerates_missing_optional_columns(self, monkeypatch):
         """A report without the optional RT columns still works."""
-        from pmultiqc.modules.common import dia_utils
-
         monkeypatch.setattr(dia_utils, "draw_dia_ids_rt", lambda *a, **k: None)
         monkeypatch.setattr(dia_utils, "cal_feature_avg_rt", lambda df, col: None)
         monkeypatch.setattr(dia_utils, "cal_rt_irt_loess", lambda df: None)

--- a/tests/test_diann.py
+++ b/tests/test_diann.py
@@ -42,3 +42,119 @@ class TestDiann:
 
         version = parse_diann_version(str(log_file))
         assert version == "2.0", f"Expected version '2.0', got '{version}'"
+
+
+class TestDiaReportMemory:
+    """The DIA plotting entry points must not duplicate the whole DIA-NN report.
+
+    On large experiments the report has tens of millions of rows and ~50 columns,
+    several of them object-dtype strings. Copying it wholesale to add one derived
+    column is what makes these steps run out of memory, so the frames handed to the
+    plotting helpers must carry only the columns those helpers read.
+    """
+
+    @staticmethod
+    def _report_df():
+        """A DIA-NN-shaped report with extra columns none of these plots use."""
+        import pandas as pd
+
+        return pd.DataFrame(
+            {
+                "Run": ["run1", "run1", "run2", "run2"],
+                "Modified.Sequence": ["PEPTIDEK", "PEPTIDER", "PEPTIDEK", "PEPTIDER"],
+                "Protein.Group": ["P1", "P2", "P1", "P2"],
+                "Precursor.Quantity": [100.0, 200.0, 0.0, 400.0],
+                "RT": [10.0, 20.0, 11.0, 21.0],
+                "iRT": [9.0, 19.0, 10.0, 20.0],
+                "Predicted.RT": [10.5, 19.5, 11.5, 20.5],
+                "RT.Start": [9.5, 19.5, 10.5, 20.5],
+                "RT.Stop": [10.5, 20.5, 11.5, 21.5],
+                "FWHM": [0.5, 0.6, 0.5, 0.6],
+                "Normalisation.Factor": [1.0, 1.1, 1.0, 1.1],
+                # Columns that must never reach the plotting helpers:
+                "Stripped.Sequence": ["PEPTIDEK", "PEPTIDER", "PEPTIDEK", "PEPTIDER"],
+                "Precursor.Id": ["PEPTIDEK2", "PEPTIDER2", "PEPTIDEK2", "PEPTIDER2"],
+                "Ms1.Area": [1.0, 2.0, 3.0, 4.0],
+            }
+        )
+
+    def test_draw_dia_intensitys_narrows_columns(self, monkeypatch):
+        """Only Run/Modified.Sequence/Protein.Group/intensity reach the plots."""
+        from pmultiqc.modules.common import dia_utils
+        import pandas as pd
+
+        captured = []
+
+        def capture(sub_section, df, sdrf_file_df):
+            captured.append(df)
+
+        monkeypatch.setattr(dia_utils.dia_plots, "draw_dia_intensity_dis", capture)
+        monkeypatch.setattr(dia_utils.dia_plots, "draw_dia_intensity_std", capture)
+
+        report_df = self._report_df()
+        dia_utils.draw_dia_intensitys(None, report_df, pd.DataFrame())
+
+        assert len(captured) == 2, "both intensity plots should be called"
+        for df in captured:
+            assert set(df.columns) == {
+                "Run",
+                "Modified.Sequence",
+                "Protein.Group",
+                "Precursor.Quantity",
+                "log_intensity",
+            }, f"unexpected columns carried into the plot: {sorted(df.columns)}"
+            # Rows with no quantity are still filtered out.
+            assert (df["Precursor.Quantity"] > 0).all()
+            assert len(df) == 3
+
+    def test_draw_dia_intensitys_does_not_mutate_report(self, monkeypatch):
+        """The caller's report must not gain a log_intensity column."""
+        from pmultiqc.modules.common import dia_utils
+        import pandas as pd
+
+        monkeypatch.setattr(
+            dia_utils.dia_plots, "draw_dia_intensity_dis", lambda *a, **k: None
+        )
+        monkeypatch.setattr(
+            dia_utils.dia_plots, "draw_dia_intensity_std", lambda *a, **k: None
+        )
+
+        report_df = self._report_df()
+        before = list(report_df.columns)
+
+        dia_utils.draw_dia_intensitys(None, report_df, pd.DataFrame())
+
+        assert list(report_df.columns) == before
+
+    def test_draw_dia_rt_qc_narrows_columns(self, monkeypatch):
+        """RT QC copies only the RT-related columns, not the whole report."""
+        from pmultiqc.modules.common import dia_utils
+
+        captured = []
+
+        def capture_ids_rt(sub_section, report_df):
+            # Snapshot the columns now: draw_dia_rt_qc adds derived columns to this
+            # same frame after this call, and we care about what it started from.
+            captured.append(list(report_df.columns))
+
+        monkeypatch.setattr(dia_utils, "draw_dia_ids_rt", capture_ids_rt)
+        monkeypatch.setattr(dia_utils, "cal_feature_avg_rt", lambda df, col: None)
+        monkeypatch.setattr(dia_utils, "cal_rt_irt_loess", lambda df: None)
+
+        dia_utils.draw_dia_rt_qc(None, self._report_df())
+
+        assert len(captured) == 1
+        assert set(captured[0]) <= set(dia_utils.RT_QC_COLUMNS)
+        assert "Stripped.Sequence" not in captured[0]
+        assert "Precursor.Id" not in captured[0]
+
+    def test_draw_dia_rt_qc_tolerates_missing_optional_columns(self, monkeypatch):
+        """A report without the optional RT columns still works."""
+        from pmultiqc.modules.common import dia_utils
+
+        monkeypatch.setattr(dia_utils, "draw_dia_ids_rt", lambda *a, **k: None)
+        monkeypatch.setattr(dia_utils, "cal_feature_avg_rt", lambda df, col: None)
+        monkeypatch.setattr(dia_utils, "cal_rt_irt_loess", lambda df: None)
+
+        minimal = self._report_df()[["Run", "RT"]]
+        dia_utils.draw_dia_rt_qc(None, minimal)


### PR DESCRIPTION
Fixes the memory half of #717.

## The problem

`draw_dia_intensitys` and `draw_dia_rt_qc` each copied the **entire** DIA-NN report just to add one derived column:

```python
df_sub = report_df[report_df["Precursor.Quantity"] > 0].copy()   # every column
df_sub["log_intensity"] = np.log2(df_sub["Precursor.Quantity"])

df = report_df.copy()                                            # every column
...
df["peak_width"] = df["RT.Stop"] - df["RT.Start"]
```

On a large experiment the report is tens of millions of rows by ~50 columns, several of them object-dtype strings (`Stripped.Sequence`, `Precursor.Id`, `Modified.Sequence`, …). Those copies scale with report *width* as well as length, and they dominate memory even though the consumers need only a handful of columns.

This was hit on a real 5,798-run DIA reanalysis, where the step was OOM-killed at 72 GB:

```
general | draw_dia_intensity_std: Plot data count: 42690601
general | draw_dia_intensity_std: Number of plotting data points: 42690601, exceeds threshold 100000, switching to flat plot
.command.sh: line 6: 43 Killed  multiqc -f --quantms-plugin ...
```

Note the existing threshold check switches the *plot type* after the data has already been materialised, so it doesn't bound memory.

## The change

Project to the needed columns **before** filtering and copying.

- `draw_dia_intensitys` keeps `Run`, `Modified.Sequence`, `Protein.Group`, `Precursor.Quantity` — exactly what `draw_dia_intensity_dis` and `calculate_dia_intensity_std` select internally.
- `draw_dia_rt_qc` keeps the new `RT_QC_COLUMNS` tuple — `Run`, `RT`, `Normalisation.Factor`, `FWHM`, `RT.Start`, `RT.Stop`, `Predicted.RT`, `iRT` — which covers `draw_dia_ids_rt`, `cal_feature_avg_rt` (`[col, "Run", "RT"]`) and `cal_rt_irt_loess` (`RT`, `Run`, `iRT`).

Both use an `if col in report_df.columns` guard, so reports missing the optional columns behave as before.

**Behaviour is unchanged** — the same frames reach the plotting helpers, the same rows are filtered, the same plots are produced. This is purely about not materialising columns nobody reads.

## Tests

Four tests in a new `TestDiaReportMemory` class, using a DIA-NN-shaped frame that deliberately includes columns none of these plots use:

- the intensity plots receive only the four expected columns plus `log_intensity`, with zero-quantity rows still filtered;
- `draw_dia_intensitys` does not mutate the caller's report;
- RT QC starts from a subset of `RT_QC_COLUMNS` and never sees `Stripped.Sequence` / `Precursor.Id`;
- a minimal `Run`/`RT`-only report still works.

I verified they're real regression tests: reverting the source change makes the two "narrows_columns" tests fail, and restoring it makes them pass. Full suite is green (190 passed).

## Not covered here

The other half of #717 — `AttributeError: module 'rich' has no attribute 'panel'` at `multiqc/core/exec_modules.py:157` — is upstream MultiQC code, not pmultiqc, so it can't be fixed from this repo. It's worth chasing separately, because it's what hid the OOM in the first place: any module exception makes MultiQC's error handler raise, destroying the original traceback and leaving a bare exit 1.
