### PR TITLE
ci: run the test workflows on pull requests to dev

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 jobs:
   test:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 jobs:
   setup:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 jobs:
   build:


### PR DESCRIPTION
`pytest.yml`, `python-app.yml` and `python-package.yml` trigger only on pull requests to `main`. Development happens on `dev`, so PRs there — which is nearly all of them — are never tested by CI. Codacy and CodeRabbit run, but nothing *executes* the code.

## Why it matters

#716 imports `pymzqc` in four places and declares it nowhere in `pyproject.toml`, so every install of that branch raises `ImportError`. A single pytest run would have caught it on day one; instead it sat for two months with a green-looking check list. #718 likewise merged-ready with zero CI runs — I had to run its 190 tests locally to know.

## Change

```diff
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
```

in all three workflows. Only the `pull_request` triggers change; pushes still build on `main` alone, so this adds no cost to merges — just to the PRs that should have had it all along.

All workflow files still parse.
