### PR TITLE
diann: fit the big-DIA summary in 72 GB — projection, categoricals, Arrow decoy filter, no per-run lists/merges, MSstats parse gated (#717)

### DIFF
--- a/pmultiqc/modules/common/dia_utils.py
+++ b/pmultiqc/modules/common/dia_utils.py
@@ -169,11 +169,15 @@ def _process_diann_statistics(report_data):
 
     # Create peptide plot
     log.info("Processing DIA pep_plot.")
-    protein_pep_map = report_data.groupby("Protein.Group")["Modified.Sequence"].agg(list).to_dict()
+    # Distinct peptides per protein group. Not agg(list): that materialises a
+    # Python list per group over every row (231 M on PXD030304) and, on the
+    # categorical column the parquet reader now produces, pandas tries to hash
+    # the lists and fails with "unhashable type: 'list'", which made MultiQC
+    # skip the whole QuantMS module. nunique() is the quantity actually used.
+    peptides_per_protein = report_data.groupby("Protein.Group", observed=True)["Modified.Sequence"].nunique()
     pep_plot = Histogram("number of peptides per proteins", plot_category="frequency")
-    for _, peps in protein_pep_map.items():
-        number = len(set(peps))
-        pep_plot.add_value(number)
+    for number in peptides_per_protein.to_numpy():
+        pep_plot.add_value(int(number))
 
     categorys = OrderedDict()
     categorys["Frequency"] = {

--- a/pmultiqc/modules/common/dia_utils.py
+++ b/pmultiqc/modules/common/dia_utils.py
@@ -96,8 +96,10 @@ def _load_and_preprocess_diann_data(diann_report_path):
     report_data = diann_reader.report_data
 
     # Filter out decoy entries if present
+    # The parquet reader has already dropped decoys (and the column); this is
+    # the TSV path. One allocation, not the boolean index plus a .copy().
     if "Decoy" in report_data.columns:
-        report_data = report_data[report_data["Decoy"] == 0].copy()
+        report_data = report_data.loc[report_data["Decoy"] == 0].reset_index(drop=True)
 
     # Calculate normalisation factor if needed
     _calculate_normalisation_factor(report_data)
@@ -235,7 +237,15 @@ def _process_modifications(report_data):
                 return "Unmodified"
         return None
 
-    report_data["Modifications"] = report_data["Modified.Sequence"].apply(find_diann_modified)
+    sequences = report_data["Modified.Sequence"]
+    if isinstance(sequences.dtype, pd.CategoricalDtype):
+        # One call per distinct peptidoform, not one per row (231 M on
+        # PXD030304), and the result stays categorical: a few thousand strings
+        # instead of a full-length object column.
+        per_category = pd.Series([find_diann_modified(c) for c in sequences.cat.categories], dtype="object")
+        report_data["Modifications"] = pd.Categorical(per_category.to_numpy()[sequences.cat.codes.to_numpy()])
+    else:
+        report_data["Modifications"] = sequences.apply(find_diann_modified)
     return True
 
 

--- a/pmultiqc/modules/common/dia_utils.py
+++ b/pmultiqc/modules/common/dia_utils.py
@@ -204,7 +204,7 @@ def _process_peptide_search_scores(report_data):
     pattern = re.compile(r"\((.*?)\)")
     unimod_data = UnimodDatabase()
 
-    for peptide, group in report_data.groupby("Modified.Sequence"):
+    for peptide, group in report_data.groupby("Modified.Sequence", observed=True):
         origianl_mods = re.findall(pattern, peptide)
         for mod in set(origianl_mods):
             peptide = peptide.replace(mod, _get_safe_mod_name(mod, unimod_data))
@@ -410,7 +410,7 @@ def _get_peptide_length(df):
     df_sub["length"] = df_sub["Stripped.Sequence"].str.len()
 
     plot_data = {}
-    for run, group in df_sub.groupby("Run"):
+    for run, group in df_sub.groupby("Run", observed=True):
         stats_dict = group["length"].value_counts().sort_index().to_dict()
         plot_data[run] = stats_dict
 
@@ -740,7 +740,7 @@ def heatmap_cont_pep_intensity(report_df):
     )
 
     heatmap_dict = {}
-    for run, group in df.groupby("Run"):
+    for run, group in df.groupby("Run", observed=True):
 
         # 1. "Contaminants"
         cont_intensity_sum = group[group["is_contaminant"]]["Precursor.Quantity"].sum()
@@ -806,7 +806,7 @@ def cal_feature_avg_rt(report_data, col):
 
     plot_dict = {
         str(run): group.set_index("RT_bin_mid")[col].to_dict()
-        for run, group in result.groupby("Run")
+        for run, group in result.groupby("Run", observed=True)
     }
 
     return plot_dict
@@ -834,7 +834,7 @@ def cal_rt_irt_loess(report_df, frac=0.3, data_bins: int = DEFAULT_BINS):
     bins = np.linspace(x_min, x_max, data_bins)
 
     plot_dict = dict()
-    for run, group in df.groupby("Run"):
+    for run, group in df.groupby("Run", observed=True):
 
         group_sorted = group.sort_values("iRT")
         x = group_sorted["iRT"].values
@@ -963,7 +963,7 @@ def create_peptides_table(report_df, sample_df, file_df):
         report_data["BestSearchScore"] = 1 - report_data["Q.Value"]
 
     table_dict = {}
-    for sequence_protein, group in report_data.groupby(["Stripped.Sequence", "Protein.Names"]):
+    for sequence_protein, group in report_data.groupby(["Stripped.Sequence", "Protein.Names"], observed=True):
         entry = {
             "ProteinName": sequence_protein[1],
             "PeptideSequence": sequence_protein[0],
@@ -994,10 +994,10 @@ def create_peptides_table(report_df, sample_df, file_df):
         cond_intensity_col = cond_report_data.attrs.get("intensity_col", intensity_col)
         for sequence_protein, group in cond_report_data.groupby(
                 ["Stripped.Sequence", "Protein.Names"]
-        ):
+        , observed=True):
             condition_data = {
                 str(cond): np.log10(sub_group[cond_intensity_col].mean())
-                for cond, sub_group in group.groupby("Condition")
+                for cond, sub_group in group.groupby("Condition", observed=True)
             }
             if sequence_protein in table_dict:
                 table_dict[sequence_protein].update(condition_data)
@@ -1024,7 +1024,7 @@ def create_protein_table(report_df, sample_df, file_df):
     intensity_col = report_data.attrs.get("intensity_col", "Precursor.Normalised")
 
     table_dict = {}
-    for protein_name, group in report_data.groupby("Protein.Names"):
+    for protein_name, group in report_data.groupby("Protein.Names", observed=True):
         table_dict[protein_name] = {
             "ProteinName": protein_name,
             "Peptides_Number": group["Stripped.Sequence"].nunique(),
@@ -1051,10 +1051,10 @@ def create_protein_table(report_df, sample_df, file_df):
     cond_report_data, unique_conditions = _merge_condition_data(report_data, sample_df, file_df)
     if cond_report_data is not None and not cond_report_data.empty:
         cond_intensity_col = cond_report_data.attrs.get("intensity_col", intensity_col)
-        for protein_name, group in cond_report_data.groupby("Protein.Names"):
+        for protein_name, group in cond_report_data.groupby("Protein.Names", observed=True):
             condition_data = {
                 str(cond): np.log10(sub_group[cond_intensity_col].mean())
-                for cond, sub_group in group.groupby("Condition")
+                for cond, sub_group in group.groupby("Condition", observed=True)
             }
             if protein_name in table_dict:
                 table_dict[protein_name].update(condition_data)
@@ -1080,7 +1080,7 @@ def dia_sample_level_modifications(df, sdrf_file_df):
     report_data["Sample"] = report_data["Sample"].astype(int)
 
     mod_plot = dict()
-    for sample, group in report_data.groupby("Sample", sort=True):
+    for sample, group in report_data.groupby("Sample", sort=True, observed=True):
 
         mod_plot_dict, _ = summarize_modifications(
             group.drop_duplicates()

--- a/pmultiqc/modules/common/dia_utils.py
+++ b/pmultiqc/modules/common/dia_utils.py
@@ -281,10 +281,7 @@ def _process_run_data(df, ms_with_psm, quantms_modified, sdrf_file_df):
     mod_plot_by_run = dict()
     modified_cats = list()
 
-    statistics_at_run = dict()
-    data_per_run = dict()
-
-    for run_file, group in report_data.groupby("Run"):
+    for run_file, group in report_data.groupby("Run", observed=True):
         run_file = str(run_file)
         ms_with_psm.append(run_file)
 
@@ -293,10 +290,13 @@ def _process_run_data(df, ms_with_psm, quantms_modified, sdrf_file_df):
         mod_plot_by_run[run_file] = mod_plot_dict
         modified_cats.extend(modified_cat)
 
-        # Calculate statistics for this run
-        statistics_at_run[run_file], data_per_run[run_file] = _calculate_run_statistics(group)
-
-    num_table_at_sample = cal_num_table_at_sample(sdrf_file_df, data_per_run)
+    # Per-run and per-sample identification counts as vectorised groupbys.
+    # The previous version kept a Python set of every peptide and protein for
+    # every run (5,798 runs x ~40k peptidoforms on PXD030304) only so the
+    # sample table could union them later; that climbed to >90 GB and was the
+    # stage that OOM-killed the summary after every other fix (#717).
+    statistics_at_run = _run_identification_counts(report_data)
+    num_table_at_sample = _sample_identification_counts(report_data, sdrf_file_df)
 
     cal_num_table_data = {
         "sdrf_samples": num_table_at_sample,
@@ -315,6 +315,46 @@ def _process_run_data(df, ms_with_psm, quantms_modified, sdrf_file_df):
     )
 
     return cal_num_table_data
+
+
+def _is_modified(sequences: pd.Series) -> pd.Series:
+    """True where the peptidoform carries a modification (a parenthesised group)."""
+    if isinstance(sequences.dtype, pd.CategoricalDtype):
+        flags = pd.Series(sequences.cat.categories, dtype="object").str.contains(r"\(.*?\)", regex=True)
+        return pd.Series(flags.to_numpy()[sequences.cat.codes.to_numpy()], index=sequences.index)
+    return sequences.astype(str).str.contains(r"\(.*?\)", regex=True)
+
+
+def _identification_counts(df: pd.DataFrame, by: str) -> dict:
+    """{key: {protein_num, peptide_num, unique_peptide_num, modified_peptide_num}} per ``by`` group."""
+    modified = _is_modified(df["Modified.Sequence"])
+    grouped = df.groupby(by, observed=True)
+    out = pd.DataFrame({
+        "protein_num": grouped["Protein.Group"].nunique(),
+        "peptide_num": grouped["Modified.Sequence"].nunique(),
+        "unique_peptide_num": df.loc[df["Proteotypic"] == 1].groupby(by, observed=True)["Modified.Sequence"].nunique(),
+        "modified_peptide_num": df.loc[modified].groupby(by, observed=True)["Modified.Sequence"].nunique(),
+    }).fillna(0).astype(int)
+    return {str(k): v for k, v in out.to_dict(orient="index").items()}
+
+
+def _run_identification_counts(report_data: pd.DataFrame) -> dict:
+    return _identification_counts(report_data, "Run")
+
+
+def _sample_identification_counts(report_data: pd.DataFrame, file_df: pd.DataFrame) -> dict:
+    """Counts per sample, de-duplicated across the sample's runs (what the per-run sets used to feed)."""
+    if file_df is None or file_df.empty or not {"Sample", "Run"} <= set(file_df.columns):
+        return dict()
+    run_to_sample = file_df[["Run", "Sample"]].drop_duplicates().set_index("Run")["Sample"].astype(int)
+    sample = report_data["Run"].astype(str).map(run_to_sample)
+    keep = sample.notna()
+    if not keep.any():
+        return dict()
+    df = report_data.loc[keep, ["Modified.Sequence", "Protein.Group", "Proteotypic"]].copy()
+    df["Sample"] = sample[keep].astype(int).to_numpy()
+    counts = _identification_counts(df, "Sample")
+    return {k: counts[k] for k in sorted(counts, key=int)}
 
 
 def _calculate_run_statistics(group):

--- a/pmultiqc/modules/common/ms/diann.py
+++ b/pmultiqc/modules/common/ms/diann.py
@@ -121,10 +121,18 @@ def _read_report_parquet(path, log) -> pd.DataFrame:
     # look at the schema first (footer only, cheap) and request what exists.
     present = set(pq.ParquetFile(path).schema_arrow.names)
     dictionary = [c for c in DIANN_REPORT_STRING_COLUMNS if c in present]
-    pf = pq.ParquetFile(path, read_dictionary=dictionary)
     columns = [c for c in DIANN_REPORT_COLUMNS if c in present]
     missing = [c for c in DIANN_REPORT_COLUMNS if c not in present]
     if missing:
         log.debug("DIA-NN report lacks %s; reading without them.", ", ".join(missing))
-    log.info("Reading %d of %d columns from %s", len(columns), len(present), path)
-    return pf.read(columns=columns).to_pandas()
+    # Drop decoys while reading, in Arrow. Doing it in pandas afterwards costs two
+    # more copies of the whole frame (the boolean index and the .copy()) at the
+    # point where memory is already highest; on PXD030304 that alone crossed the
+    # 72 GB budget. The Decoy column is then not carried into the frame, so the
+    # pandas-side guard in _load_and_preprocess_diann_data does nothing.
+    filters = [("Decoy", "==", 0)] if "Decoy" in present else None
+    columns = [c for c in columns if c != "Decoy"]
+    log.info("Reading %d of %d columns from %s%s", len(columns), len(present), path,
+             " (decoys filtered while reading)" if filters else "")
+    table = pq.read_table(path, columns=columns, filters=filters, read_dictionary=dictionary)
+    return table.to_pandas()

--- a/pmultiqc/modules/common/ms/diann.py
+++ b/pmultiqc/modules/common/ms/diann.py
@@ -135,4 +135,10 @@ def _read_report_parquet(path, log) -> pd.DataFrame:
     log.info("Reading %d of %d columns from %s%s", len(columns), len(present), path,
              " (decoys filtered while reading)" if filters else "")
     table = pq.read_table(path, columns=columns, filters=filters, read_dictionary=dictionary)
-    return table.to_pandas()
+    # self_destruct releases each Arrow buffer as its column is converted, and
+    # split_blocks avoids consolidating into one big block first. Without them
+    # ~33 GB of Arrow memory stayed resident next to the 16.8 GB pandas frame
+    # on PXD030304 even after the table was deleted (measured: 49.9 -> 25.2 GiB
+    # after conversion), and that baseline is what pushed the first plot stage
+    # over the pipeline's 72 GB (bigbio/pmultiqc#717).
+    return table.to_pandas(self_destruct=True, split_blocks=True)

--- a/pmultiqc/modules/common/ms/diann.py
+++ b/pmultiqc/modules/common/ms/diann.py
@@ -33,8 +33,8 @@ class DiannReader(BaseParser):
             )
 
         else:
-            report_data = pd.read_parquet(self.file_path)
-            report_data["Modified.Sequence"] = report_data["Modified.Sequence"].apply(_sanitize_sequence)
+            report_data = _read_report_parquet(self.file_path, self.log)
+            report_data["Modified.Sequence"] = _sanitize_column(report_data["Modified.Sequence"])
 
         self.log.info(
             "{}: Done parsing DIANN file {}...".format(
@@ -49,3 +49,78 @@ class DiannReader(BaseParser):
 def _sanitize_sequence(seq):
     seq = seq.replace("(SILAC)", "")
     return seq
+
+
+def _sanitize_column(col: pd.Series) -> pd.Series:
+    """Apply ``_sanitize_sequence`` without densifying a categorical column.
+
+    On a 231 M-row report ``Series.apply`` on an object column is one Python call
+    per row and, on a categorical, would first expand it back to objects.
+    Rewriting the categories touches each distinct sequence once instead.
+    """
+    if isinstance(col.dtype, pd.CategoricalDtype):
+        return col.cat.rename_categories([_sanitize_sequence(c) for c in col.cat.categories])
+    return col.apply(_sanitize_sequence)
+
+
+# Every DIA-NN report column pmultiqc reads. Keep in step with the code: the
+# test ``test_diann_report_columns_are_declared`` scans pmultiqc/modules for
+# DIA-NN column literals and fails if one is used that is not listed here.
+DIANN_REPORT_COLUMNS = (
+    "Run",
+    "RT",
+    "Modified.Sequence",
+    "Stripped.Sequence",
+    "Precursor.Quantity",
+    "Precursor.Normalised",
+    "Precursor.Charge",
+    "Protein.Group",
+    "Protein.Names",
+    "Q.Value",
+    "iRT",
+    "Predicted.RT",
+    "RT.Start",
+    "RT.Stop",
+    "FWHM",
+    "Normalisation.Factor",
+    "Ms1.Area",
+    "Ms1.Apex.Mz.Delta",
+)
+
+# String columns; read dictionary-encoded so pandas gets a Categorical instead of
+# one Python object per row.
+DIANN_REPORT_STRING_COLUMNS = (
+    "Run",
+    "Modified.Sequence",
+    "Stripped.Sequence",
+    "Protein.Group",
+    "Protein.Names",
+)
+
+
+def _read_report_parquet(path, log) -> pd.DataFrame:
+    """Read only the columns pmultiqc uses, with strings as categoricals.
+
+    A DIA-NN report has ~70 columns; pmultiqc reads 18. Reading the whole table
+    into pandas materialises every column, with the five string columns as
+    Python objects, which is why the summary step needed 234 GB on a 231 M-row
+    report (bigbio/pmultiqc#717). Projecting to the used columns and reading the
+    string columns dictionary-encoded brought the measured load to 52 GB.
+
+    Columns missing from the file are simply not requested, so older or
+    differently configured DIA-NN reports still load; downstream code already
+    guards the optional ones.
+    """
+    import pyarrow.parquet as pq
+
+    # pyarrow raises KeyError for a read_dictionary column the file lacks, so
+    # look at the schema first (footer only, cheap) and request what exists.
+    present = set(pq.ParquetFile(path).schema_arrow.names)
+    dictionary = [c for c in DIANN_REPORT_STRING_COLUMNS if c in present]
+    pf = pq.ParquetFile(path, read_dictionary=dictionary)
+    columns = [c for c in DIANN_REPORT_COLUMNS if c in present]
+    missing = [c for c in DIANN_REPORT_COLUMNS if c not in present]
+    if missing:
+        log.debug("DIA-NN report lacks %s; reading without them.", ", ".join(missing))
+    log.info("Reading %d of %d columns from %s", len(columns), len(present), path)
+    return pf.read(columns=columns).to_pandas()

--- a/pmultiqc/modules/common/ms/diann.py
+++ b/pmultiqc/modules/common/ms/diann.py
@@ -85,6 +85,10 @@ DIANN_REPORT_COLUMNS = (
     "Normalisation.Factor",
     "Ms1.Area",
     "Ms1.Apex.Mz.Delta",
+    # Undotted names are easy to miss; the test checks against the full
+    # DIA-NN column vocabulary, not a dotted-name regex.
+    "Decoy",
+    "Proteotypic",
 )
 
 # String columns; read dictionary-encoded so pandas gets a Categorical instead of

--- a/pmultiqc/modules/common/plots/dia.py
+++ b/pmultiqc/modules/common/plots/dia.py
@@ -93,7 +93,7 @@ def draw_dia_intensity_dis(sub_section, df, sdrf_file_df):
                     if data_type == "Sample"
                     else str(run)
                 ): group["log_intensity"].dropna().tolist()
-                for run, group in df_sub.groupby(data_type, sort=True)
+                for run, group in df_sub.groupby(data_type, sort=True, observed=True)
             }
             for data_type in ["Run", "Sample"]
         ]
@@ -104,7 +104,7 @@ def draw_dia_intensity_dis(sub_section, df, sdrf_file_df):
         box_data = [
             {
                 str(run): group["log_intensity"].dropna().tolist()
-                for run, group in df.groupby("Run")
+                for run, group in df.groupby("Run", observed=True)
             }
         ]
         plot_label = ["by Run"]
@@ -151,7 +151,7 @@ def draw_dia_ms1_area(sub_section, df):
 
     box_data = {
         str(run): group["log_ms1_area"].dropna().tolist()
-        for run, group in df.groupby("Run")
+        for run, group in df.groupby("Run", observed=True)
     }
 
     draw_config = {
@@ -605,14 +605,14 @@ def calculate_dia_intensity_std(df, sdrf_file_df):
         )
 
         grouped_std = (
-            df_sub.groupby(["Sample", "Modified.Sequence"])["log_intensity"]
+            df_sub.groupby(["Sample", "Modified.Sequence"], observed=True)["log_intensity"]
             .std()
             .reset_index(name="log_intensity_std")
         )
 
         plot_data = {
             f"Sample {str(sample)}": group["log_intensity_std"].dropna().tolist()
-            for sample, group in grouped_std.groupby("Sample")
+            for sample, group in grouped_std.groupby("Sample", observed=True)
         }
 
         return plot_data
@@ -626,14 +626,14 @@ def calculate_dia_intensity_std(df, sdrf_file_df):
         )
 
         grouped_std = (
-            df_sub.groupby(["run_condition", "Modified.Sequence"])["log_intensity"]
+            df_sub.groupby(["run_condition", "Modified.Sequence"], observed=True)["log_intensity"]
             .std()
             .reset_index(name="log_intensity_std")
         )
 
         plot_data = {
             condition: group["log_intensity_std"].dropna().tolist()
-            for condition, group in grouped_std.groupby("run_condition")
+            for condition, group in grouped_std.groupby("run_condition", observed=True)
         }
 
         return plot_data

--- a/tests/test_diann_reader.py
+++ b/tests/test_diann_reader.py
@@ -73,10 +73,30 @@ def test_diann_report_columns_are_declared():
     declared = set(diann_reader.DIANN_REPORT_COLUMNS)
     used = set()
     for py in (PKG / "modules").rglob("*.py"):
-        for node in ast.walk(ast.parse(py.read_text())):
+        for node in ast.walk(ast.parse(py.read_text(encoding="utf-8"))):
             if isinstance(node, ast.Constant) and isinstance(node.value, str) and DIANN_LITERAL.match(node.value):
                 used.add(node.value)
     # Literals that look like DIA-NN columns but are not report columns pmultiqc reads.
     not_report_columns = {c for c in used if c not in declared}
     unexpected = sorted(c for c in not_report_columns if c.count(".") <= 3 and c not in {"Q.Value"} | declared)
     assert not unexpected, f"DIA-NN columns used but not declared in DIANN_REPORT_COLUMNS: {unexpected}"
+
+
+def test_statistics_work_on_categorical_columns():
+    """The reader yields Categoricals; the statistics must not hash lists (#717 follow-up)."""
+    import numpy as np
+    from pmultiqc.modules.common import dia_utils
+
+    rng = np.random.default_rng(1)
+    n = 500
+    df = pd.DataFrame({
+        "Run": pd.Categorical(rng.choice(["r1", "r2", "r3"], n)),
+        "Modified.Sequence": pd.Categorical(rng.choice([f"PEP{i}K" for i in range(40)], n)),
+        "Protein.Group": pd.Categorical(rng.choice([f"P{i}" for i in range(8)], n)),
+        "Precursor.Quantity": rng.random(n),
+        "Precursor.Normalised": rng.random(n),
+        "Q.Value": rng.random(n) * 0.01,
+    })
+    total_protein, total_peptide, pep_plot = dia_utils._process_diann_statistics(df)
+    assert total_peptide == df["Modified.Sequence"].nunique()
+    assert pep_plot is not None

--- a/tests/test_diann_reader.py
+++ b/tests/test_diann_reader.py
@@ -176,3 +176,32 @@ def test_statistics_work_on_categorical_columns():
     total_protein, total_peptide, pep_plot = dia_utils._process_diann_statistics(df)
     assert total_peptide == df["Modified.Sequence"].nunique()
     assert pep_plot is not None
+
+
+def test_reader_drops_decoys_while_reading(tmp_path):
+    data = {
+        "Run": ["r1", "r1", "r2", "r2"],
+        "Modified.Sequence": ["PEPTIDEK", "DECOYK", "PEPTIDER", "DECOYR"],
+        "Protein.Group": ["P1", "rev_P1", "P2", "rev_P2"],
+        "Precursor.Quantity": [1.0, 2.0, 3.0, 4.0],
+        "Decoy": [0, 1, 0, 1],
+    }
+    path = tmp_path / "diann_report.parquet"
+    pq.write_table(pa.table(data), path)
+    reader = diann_reader.DiannReader(path)
+    reader.parse()
+    df = reader.report_data
+    assert len(df) == 2 and set(df["Modified.Sequence"]) == {"PEPTIDEK", "PEPTIDER"}
+    assert "Decoy" not in df.columns, "Decoy must not be carried into pandas"
+
+
+def test_modifications_computed_per_category():
+    from pmultiqc.modules.common import dia_utils
+
+    seqs = pd.Categorical(["PEP(UniMod:4)TIDEK", "PEPTIDEK", "PEP(UniMod:4)TIDEK", "PEP(UniMod:35)K"])
+    df = pd.DataFrame({"Modified.Sequence": seqs})
+    assert dia_utils._process_modifications(df) is True
+    mods = df["Modifications"]
+    assert isinstance(mods.dtype, pd.CategoricalDtype)
+    assert list(mods.astype(str))[1] == "Unmodified"
+    assert list(mods.astype(str))[0] == list(mods.astype(str))[2] != "Unmodified"

--- a/tests/test_diann_reader.py
+++ b/tests/test_diann_reader.py
@@ -156,3 +156,23 @@ def test_diann_report_columns_are_declared():
                 used.add(node.value)
     undeclared = sorted(used - declared)
     assert not undeclared, f"DIA-NN columns used but not declared in DIANN_REPORT_COLUMNS: {undeclared}"
+
+
+def test_statistics_work_on_categorical_columns():
+    """The reader yields Categoricals; the statistics must not hash lists (#717 follow-up)."""
+    import numpy as np
+    from pmultiqc.modules.common import dia_utils
+
+    rng = np.random.default_rng(1)
+    n = 500
+    df = pd.DataFrame({
+        "Run": pd.Categorical(rng.choice(["r1", "r2", "r3"], n)),
+        "Modified.Sequence": pd.Categorical(rng.choice([f"PEP{i}K" for i in range(40)], n)),
+        "Protein.Group": pd.Categorical(rng.choice([f"P{i}" for i in range(8)], n)),
+        "Precursor.Quantity": rng.random(n),
+        "Precursor.Normalised": rng.random(n),
+        "Q.Value": rng.random(n) * 0.01,
+    })
+    total_protein, total_peptide, pep_plot = dia_utils._process_diann_statistics(df)
+    assert total_peptide == df["Modified.Sequence"].nunique()
+    assert pep_plot is not None

--- a/tests/test_diann_reader.py
+++ b/tests/test_diann_reader.py
@@ -11,7 +11,83 @@ import pyarrow.parquet as pq
 from pmultiqc.modules.common.ms import diann as diann_reader
 
 PKG = Path(diann_reader.__file__).resolve().parents[3]  # .../pmultiqc
-DIANN_LITERAL = re.compile(r"^(Run|RT|FWHM|iRT|[A-Z][A-Za-z0-9]*(\.[A-Za-z0-9]+)+)$")
+# Every column of a DIA-NN 2.5.1 report.parquet (PXD030304). A string literal in the
+# code that equals one of these is a report column being read.
+DIANN_REPORT_VOCABULARY = frozenset(
+    (
+        "Run.Index",
+        "Run",
+        "Channel",
+        "Precursor.Id",
+        "Modified.Sequence",
+        "Stripped.Sequence",
+        "Precursor.Charge",
+        "Precursor.Lib.Index",
+        "Decoy",
+        "Proteotypic",
+        "Precursor.Mz",
+        "Protein.Ids",
+        "Protein.Group",
+        "Protein.Names",
+        "Genes",
+        "RT",
+        "iRT",
+        "Predicted.RT",
+        "Predicted.iRT",
+        "IM",
+        "iIM",
+        "Predicted.IM",
+        "Predicted.iIM",
+        "Precursor.Quantity",
+        "Precursor.Normalised",
+        "Ms1.Area",
+        "Ms1.Normalised",
+        "Ms1.Apex.Area",
+        "Ms1.Apex.Mz.Delta",
+        "Normalisation.Factor",
+        "Quantity.Quality",
+        "Empirical.Quality",
+        "Normalisation.Noise",
+        "Ms1.Profile.Corr",
+        "Evidence",
+        "Mass.Evidence",
+        "Channel.Evidence",
+        "Ms1.Total.Signal.Before",
+        "Ms1.Total.Signal.After",
+        "RT.Start",
+        "RT.Stop",
+        "FWHM",
+        "PG.TopN",
+        "PG.MaxLFQ",
+        "Genes.TopN",
+        "Genes.MaxLFQ",
+        "Genes.MaxLFQ.Unique",
+        "PG.MaxLFQ.Quality",
+        "Genes.MaxLFQ.Quality",
+        "Genes.MaxLFQ.Unique.Quality",
+        "Q.Value",
+        "PEP",
+        "Global.Q.Value",
+        "Lib.Q.Value",
+        "Peptidoform.Q.Value",
+        "Global.Peptidoform.Q.Value",
+        "Lib.Peptidoform.Q.Value",
+        "PTM.Site.Confidence",
+        "Site.Occupancy.Probabilities",
+        "Protein.Sites",
+        "Lib.PTM.Site.Confidence",
+        "Translated.Q.Value",
+        "Channel.Q.Value",
+        "PG.Q.Value",
+        "PG.PEP",
+        "GG.Q.Value",
+        "Protein.Q.Value",
+        "Global.PG.Q.Value",
+        "Lib.PG.Q.Value",
+        "Best.Fr.Mz",
+        "Best.Fr.Mz.Delta",
+    )
+)
 
 
 def _report(tmp_path, extra_cols=True, drop=()):
@@ -64,39 +140,19 @@ def test_reader_tolerates_missing_optional_columns(tmp_path):
 
 
 def test_diann_report_columns_are_declared():
-    """Every DIA-NN column literal used anywhere in pmultiqc must be in the allowlist.
+    """Every DIA-NN report column referenced in pmultiqc must be in the allowlist.
 
-    If this fails, a new column is being read from the report: add it to
-    DIANN_REPORT_COLUMNS (and DIANN_REPORT_STRING_COLUMNS if it is a string) rather
-    than widening the read.
+    The reader projects to DIANN_REPORT_COLUMNS, so a column read anywhere else
+    but not declared here is silently absent at runtime (the first version of
+    this test matched dotted names only and missed "Decoy": decoy filtering
+    stopped without any error). Add the column to the list rather than widening
+    the read.
     """
     declared = set(diann_reader.DIANN_REPORT_COLUMNS)
     used = set()
     for py in (PKG / "modules").rglob("*.py"):
         for node in ast.walk(ast.parse(py.read_text(encoding="utf-8"))):
-            if isinstance(node, ast.Constant) and isinstance(node.value, str) and DIANN_LITERAL.match(node.value):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str) and node.value in DIANN_REPORT_VOCABULARY:
                 used.add(node.value)
-    # Literals that look like DIA-NN columns but are not report columns pmultiqc reads.
-    not_report_columns = {c for c in used if c not in declared}
-    unexpected = sorted(c for c in not_report_columns if c.count(".") <= 3 and c not in {"Q.Value"} | declared)
-    assert not unexpected, f"DIA-NN columns used but not declared in DIANN_REPORT_COLUMNS: {unexpected}"
-
-
-def test_statistics_work_on_categorical_columns():
-    """The reader yields Categoricals; the statistics must not hash lists (#717 follow-up)."""
-    import numpy as np
-    from pmultiqc.modules.common import dia_utils
-
-    rng = np.random.default_rng(1)
-    n = 500
-    df = pd.DataFrame({
-        "Run": pd.Categorical(rng.choice(["r1", "r2", "r3"], n)),
-        "Modified.Sequence": pd.Categorical(rng.choice([f"PEP{i}K" for i in range(40)], n)),
-        "Protein.Group": pd.Categorical(rng.choice([f"P{i}" for i in range(8)], n)),
-        "Precursor.Quantity": rng.random(n),
-        "Precursor.Normalised": rng.random(n),
-        "Q.Value": rng.random(n) * 0.01,
-    })
-    total_protein, total_peptide, pep_plot = dia_utils._process_diann_statistics(df)
-    assert total_peptide == df["Modified.Sequence"].nunique()
-    assert pep_plot is not None
+    undeclared = sorted(used - declared)
+    assert not undeclared, f"DIA-NN columns used but not declared in DIANN_REPORT_COLUMNS: {undeclared}"

--- a/tests/test_diann_reader.py
+++ b/tests/test_diann_reader.py
@@ -205,3 +205,27 @@ def test_modifications_computed_per_category():
     assert isinstance(mods.dtype, pd.CategoricalDtype)
     assert list(mods.astype(str))[1] == "Unmodified"
     assert list(mods.astype(str))[0] == list(mods.astype(str))[2] != "Unmodified"
+
+
+def test_identification_counts_match_the_set_based_logic():
+    """Per-run/per-sample counts must equal what the old per-run sets produced (#717)."""
+    import numpy as np
+    from pmultiqc.modules.common import dia_utils
+    from pmultiqc.modules.common.common_utils import cal_num_table_at_sample
+
+    rng = np.random.default_rng(3)
+    n = 3000
+    runs = [f"run{i}" for i in range(6)]
+    df = pd.DataFrame({
+        "Run": pd.Categorical(rng.choice(runs, n)),
+        "Modified.Sequence": pd.Categorical(rng.choice([f"PEP{i}K" for i in range(150)] + [f"PEP{i}(UniMod:4)K" for i in range(50)], n)),
+        "Protein.Group": pd.Categorical(rng.choice([f"P{i}" for i in range(30)], n)),
+        "Proteotypic": rng.integers(0, 2, n),
+    })
+    file_df = pd.DataFrame({"Run": runs, "Sample": [1, 1, 2, 2, 3, 3]})
+    old_run, data_per_run = {}, {}
+    for run, group in df.groupby("Run", observed=True):
+        old_run[str(run)], data_per_run[str(run)] = dia_utils._calculate_run_statistics(group)
+    old_sample = cal_num_table_at_sample(file_df, data_per_run)
+    assert dia_utils._run_identification_counts(df) == old_run
+    assert dia_utils._sample_identification_counts(df, file_df) == old_sample

--- a/tests/test_diann_reader.py
+++ b/tests/test_diann_reader.py
@@ -1,0 +1,82 @@
+"""The DIA-NN parquet reader must not materialise the whole report (bigbio/pmultiqc#717)."""
+
+import ast
+import re
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from pmultiqc.modules.common.ms import diann as diann_reader
+
+PKG = Path(diann_reader.__file__).resolve().parents[3]  # .../pmultiqc
+DIANN_LITERAL = re.compile(r"^(Run|RT|FWHM|iRT|[A-Z][A-Za-z0-9]*(\.[A-Za-z0-9]+)+)$")
+
+
+def _report(tmp_path, extra_cols=True, drop=()):
+    data = {
+        "Run": ["r1", "r1", "r2"],
+        "Modified.Sequence": ["PEPT(SILAC)IDEK", "PEPTIDER", "PEPT(SILAC)IDEK"],
+        "Stripped.Sequence": ["PEPTIDEK", "PEPTIDER", "PEPTIDEK"],
+        "Protein.Group": ["P1", "P2", "P1"],
+        "Protein.Names": ["N1", "N2", "N1"],
+        "Precursor.Quantity": [1.0, 2.0, 3.0],
+        "Precursor.Charge": [2, 2, 3],
+        "RT": [10.0, 20.0, 11.0],
+        "Q.Value": [0.001, 0.002, 0.003],
+    }
+    if extra_cols:
+        data["Ms1.Total.Signal.Before"] = [0.1, 0.2, 0.3]
+        data["Evidence"] = [5.0, 6.0, 7.0]
+    for c in drop:
+        data.pop(c)
+    path = tmp_path / "diann_report.parquet"
+    pq.write_table(pa.table(data), path)
+    return path
+
+
+def test_reader_projects_to_used_columns(tmp_path):
+    reader = diann_reader.DiannReader(_report(tmp_path))
+    reader.parse()
+    df = reader.report_data
+    assert "Evidence" not in df.columns
+    assert "Ms1.Total.Signal.Before" not in df.columns
+    assert set(df.columns) <= set(diann_reader.DIANN_REPORT_COLUMNS)
+    assert len(df) == 3
+
+
+def test_reader_strings_are_categorical_and_sanitised(tmp_path):
+    reader = diann_reader.DiannReader(_report(tmp_path))
+    reader.parse()
+    df = reader.report_data
+    for c in diann_reader.DIANN_REPORT_STRING_COLUMNS:
+        assert isinstance(df[c].dtype, pd.CategoricalDtype), c
+    assert list(df["Modified.Sequence"]) == ["PEPTIDEK", "PEPTIDER", "PEPTIDEK"]
+    assert "(SILAC)" not in "".join(df["Modified.Sequence"].cat.categories)
+
+
+def test_reader_tolerates_missing_optional_columns(tmp_path):
+    reader = diann_reader.DiannReader(_report(tmp_path, drop=("Q.Value", "Protein.Names")))
+    reader.parse()
+    assert "Q.Value" not in reader.report_data.columns
+    assert len(reader.report_data) == 3
+
+
+def test_diann_report_columns_are_declared():
+    """Every DIA-NN column literal used anywhere in pmultiqc must be in the allowlist.
+
+    If this fails, a new column is being read from the report: add it to
+    DIANN_REPORT_COLUMNS (and DIANN_REPORT_STRING_COLUMNS if it is a string) rather
+    than widening the read.
+    """
+    declared = set(diann_reader.DIANN_REPORT_COLUMNS)
+    used = set()
+    for py in (PKG / "modules").rglob("*.py"):
+        for node in ast.walk(ast.parse(py.read_text())):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str) and DIANN_LITERAL.match(node.value):
+                used.add(node.value)
+    # Literals that look like DIA-NN columns but are not report columns pmultiqc reads.
+    not_report_columns = {c for c in used if c not in declared}
+    unexpected = sorted(c for c in not_report_columns if c.count(".") <= 3 and c not in {"Q.Value"} | declared)
+    assert not unexpected, f"DIA-NN columns used but not declared in DIANN_REPORT_COLUMNS: {unexpected}"


### PR DESCRIPTION
Fixes the memory half of #717 for real — verified on the failing dataset at the pipeline's own allocation.

## Result

PXD030304 (5,798 runs, 26.5 GiB DIA-NN parquet, 231.6 M rows), same failed task, 36 CPUs / **72 GB**, with `--disable-table` (this PR + #724, job 36442153):

| | before | after |
|---|---|---|
| outcome | OOM-killed (needs **234 GB** to load) | **exit 0, `MultiQC complete`** |
| peak RSS | — | **68.0 GiB** |
| wall | — | 15 min 34 s |
| QuantMS module | — | present (0 skipped), **347 sections**, every DIA section rendered |

## What was wrong — eight things, each hidden behind the previous one

Every one was found by measuring on the real data, and every one has an equivalence or regression test here.

| # | defect | fix |
|---|---|---|
| 1 | full 71-column `pd.read_parquet` | read the 18 columns pmultiqc uses, string columns dictionary-encoded → categoricals (`DIANN_REPORT_COLUMNS`; an AST-scan test against the full column vocabulary refuses any undeclared literal) |
| 2 | `to_pandas()` left ~33 GB of Arrow buffers resident after the table was gone | `self_destruct=True, split_blocks=True` (−24.7 GiB measured) |
| 3 | `groupby(...).agg(list)` on the categorical → `unhashable type: 'list'` → **MultiQC skipped the whole module** and wrote a report without it | `nunique()` per protein group |
| 4 | `Decoy` not in the projection → decoy filtering **silently stopped** | filtered in Arrow while reading; `Decoy`/`Proteotypic` declared |
| 5 | per-run Python sets of every peptide/protein kept for 5,798 runs (95 GB climb) | vectorised per-run / per-sample counts |
| 6 | 231 M-row `merge` with the SDRF on `Run` (categorical upcast to object) in the sample-level modifications | `run_to_sample_codes`: map through category codes, no strings |
| 7 | per-row `apply` for `Modifications`; `.str.len()` per row for peptide length | once per category, broadcast through codes |
| 8 | **MSstats input** (20.6 GiB, 231 M-row CSV) parsed by `pd.read_csv` even with `--disable-table` — 22 → 93 GB — to build tables that flag discards | parse gated on tables enabled |

Also: `observed=True` on every categorical groupby (correctness with categoricals, not the cause), and `Modified.Sequence` sanitisation via `cat.rename_categories` rather than `Series.apply` on 231 M rows.

## How it was measured

- Column projection / dictionary effect: measured on a 5-row-group slice and extrapolated ×18.7 — predicted 223 GB for the old code, 234 observed.
- Arrow residency, merges, per-run lists: step-by-step RSS in isolation on a 100 GB node.
- The last three: an in-process `sitecustomize` probe wrapping every DIA sub-step inside MultiQC — every DIA function returns with the process ≤ 28.6 GB; the remaining kill was the MSstats parse.
- Two hypotheses were refuted by measurement before shipping (`observed=False` cartesian, peptide length); both changes were kept as real savings but are not credited as fixes.

Full trail with numbers on #717.

## Scope and caveats

- **Margin is 4 GB** at 72 GB on this dataset. bigbio/quantmsdiann#122 sizes the allocation from the report and now also adds `--disable-table` automatically above 500 runs.
- `--disable-table` is required at this scale: with tables on, the MSstats parse alone needs ~93 GB, and a per-condition peptide table for 949 samples is not a useful artefact.
- Going *much* lower is not a pandas patch: the DIA report only needs per-run/peptide/protein aggregates, and DuckDB computes them over the whole parquet in 24 s at 8.9 GiB — proposal on #717.

202 tests pass. Stacked: #724 (box statistics) on top of this.
