### PR TITLE
deps: allow multiqc 1.35 (fixes the rich.panel crash that masks module errors)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 requires-python = ">=3.10, <3.14"
 dependencies = [
     "pymzqc>=1.0.0",
-    "multiqc>=1.29, <=1.33",
+    "multiqc>=1.29, <=1.35",
     "pandas>=1.5",
     "pyteomics",
     "psims",


### PR DESCRIPTION
Second half of #717.

multiqc ≤1.34 uses `rich.panel.Panel` in its module-broke exception handler without importing `rich.panel`; rich ≥14.3 stopped importing submodules eagerly, so **any** module exception becomes

```
AttributeError: module 'rich' has no attribute 'panel'
```

and the real traceback is never shown. That is what hid the actual failures on PXD030304 (an OOM, and later a polars panic) until I captured stderr directly. Fixed upstream in multiqc 1.35 ([MultiQC#3536](https://github.com/MultiQC/MultiQC/issues/3536)): `multiqc/core/exec_modules.py` uses `rich.panel.Panel` on v1.33 and no longer does on v1.35.

I reproduced it in a fresh `python3.12` venv with multiqc 1.33 + rich 15.0.0, so it is not drift in the 0.0.47 container — every current install has it.

**Change:** `multiqc>=1.29, <=1.33` → `<=1.35`. Nothing else.

**Verification:** pmultiqc's full suite passes on 1.35 — 190/190 (and 194/194 together with #722).