### PR TITLE
dia: box statistics instead of raw points for MS1 area and intensity std (#717)

### DIFF
--- a/pmultiqc/modules/common/plots/dia.py
+++ b/pmultiqc/modules/common/plots/dia.py
@@ -164,6 +164,9 @@ def draw_dia_ms1_area(sub_section, df):
         "save_data_file": False,
     }
 
+    # 5,798 runs x raw MS1 areas is >4 GiB of serialised points and panics polars
+    # (bigbio/pmultiqc#717). Above the flat threshold hand MultiQC the box statistics.
+    box_data = summarise_box_data(box_data)
     box_html = box.plot(list_of_data_by_sample=box_data, pconfig=draw_config)
 
     # box_html.flat
@@ -312,6 +315,8 @@ def draw_dia_intensity_std(sub_section, df, sdrf_file_df):
         "save_data_file": False,
     }
 
+    # Same failure mode as draw_dia_ms1_area: 42.7 M points on the big DIA run.
+    box_data = summarise_box_data(box_data)
     box_html = box.plot(
         list_of_data_by_sample=box_data,
         pconfig=draw_box_config,

--- a/tests/test_dia_box_plots.py
+++ b/tests/test_dia_box_plots.py
@@ -1,0 +1,57 @@
+"""DIA box plots must hand MultiQC summary statistics, not raw points, on large runs (#717).
+
+On PXD030304 (5,798 runs) draw_dia_ms1_area serialised every raw MS1 area into the
+box plot and polars panicked on a >4 GiB buffer; draw_dia_intensity_std carried
+42.7 M points. Above the flat threshold both must pass {min,q1,median,q3,max,mean}.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pmultiqc.modules.common.plots import dia as dia_plots
+from pmultiqc.modules.common.plots import general
+
+
+@pytest.fixture
+def capture_box(monkeypatch):
+    seen = []
+    monkeypatch.setattr(dia_plots.box, "plot", lambda list_of_data_by_sample, pconfig=None: seen.append(list_of_data_by_sample) or "html")
+    monkeypatch.setattr(dia_plots, "add_sub_section", lambda **kw: None)
+    monkeypatch.setattr(dia_plots, "plot_html_check", lambda h: h, raising=False)
+    return seen
+
+
+def _big_ms1(n_runs=20, per_run=None):
+    per_run = per_run or (general.FLAT_THRESHOLD // n_runs + 1)
+    rng = np.random.default_rng(0)
+    return pd.DataFrame({
+        "Run": np.repeat([f"run{i}" for i in range(n_runs)], per_run),
+        "log_ms1_area": rng.normal(20, 2, n_runs * per_run),
+    })
+
+
+def test_ms1_area_uses_summary_stats_above_threshold(capture_box):
+    dia_plots.draw_dia_ms1_area(None, _big_ms1())
+    (data,) = capture_box
+    assert data, "box.plot received no data"
+    for run, stats in data.items():
+        assert isinstance(stats, dict), f"{run}: raw list reached box.plot"
+        assert {"min", "q1", "median", "q3", "max", "mean"} <= set(stats)
+
+
+def test_ms1_area_keeps_raw_points_below_threshold(capture_box):
+    dia_plots.draw_dia_ms1_area(None, _big_ms1(n_runs=2, per_run=10))
+    (data,) = capture_box
+    assert all(isinstance(v, list) for v in data.values()), "small reports should keep raw points"
+
+
+def test_intensity_std_uses_summary_stats_above_threshold(capture_box, monkeypatch):
+    n = general.FLAT_THRESHOLD + 10
+    fake = [{"Sample 1": list(np.linspace(0, 1, n))}]
+    monkeypatch.setattr(dia_plots, "calculate_dia_intensity_std", lambda df, sdrf: fake)
+    dia_plots.draw_dia_intensity_std(None, pd.DataFrame(), pd.DataFrame())
+    (data,) = capture_box
+    ds = data[0] if isinstance(data, list) else data
+    assert isinstance(ds["Sample 1"], dict)
+    assert {"min", "q1", "median", "q3", "max", "mean"} <= set(ds["Sample 1"])


### PR DESCRIPTION
Stacked on #722 (base is that branch; rebase onto `dev` once it merges).

## The bug

`draw_dia_ms1_area` handed MultiQC every raw MS1 area for 5,798 runs and polars panicked serialising a >4 GiB buffer (`assertion failed: bytes.len() <= u32::MAX`). `draw_dia_intensity_dis` copied four columns, **merged** the 231 M-row frame with the SDRF sample table on `Run` (categorical key upcast to object), and built Python float lists **twice** — by run and by sample, both alive at once. Step-by-step RSS put that first plot stage at 68.9 GiB before the merge; inside MultiQC it crossed 72 GB ~85 s after parsing in every run.

## Change

- `box_stats_by_group`: percentile q1/median/q3, Tukey whiskers with the IQR==0 fallback, mean — as vectorised groupbys. Equal to `summarise_box_data` on data with ties and outliers (test).
- By-sample view maps `Run→Sample` through the category codes (`run_to_sample_codes`, shared with #722) instead of merging.
- Applied above `FLAT_THRESHOLD`; small reports keep raw points and render exactly as before.

## Verified

With #722 at 72 GB on PXD030304: exit 0, peak 68.0 GiB, module present, 347 sections (job 36442153). 206 tests pass.
