### PR TITLE
dia: the remaining #717 fixes that did not reach dev (late #722 commits + #724)

### DIFF
--- a/pmultiqc/modules/common/dia_utils.py
+++ b/pmultiqc/modules/common/dia_utils.py
@@ -402,23 +402,36 @@ def _handle_files_without_psm(ms_paths, ms_with_psm, cal_num_table_data):
 
 
 def _get_peptide_length(df):
+    """{run: {length: count}} without materialising the sequences.
 
+    ``.str.len()`` on the categorical column converts every row back to a
+    Python string (231 M on PXD030304) and the per-run value_counts loop runs
+    5,798 times - a transient that OOM-killed the summary after mod_plot_dict
+    with no log line of its own (bigbio/pmultiqc#717). Length is computed once
+    per distinct sequence and broadcast through the codes; the histogram is a
+    single grouped size.
+    """
     if "Stripped.Sequence" not in df.columns:
         return None
-
-    df_sub = df[["Run", "Stripped.Sequence"]].copy()
-    df_sub["length"] = df_sub["Stripped.Sequence"].str.len()
-
+    seqs = df["Stripped.Sequence"]
+    if isinstance(seqs.dtype, pd.CategoricalDtype):
+        per_category = seqs.cat.categories.astype(str).str.len().to_numpy()
+        codes = seqs.cat.codes.to_numpy()
+        lengths = np.where(codes >= 0, per_category[np.clip(codes, 0, None)], -1)
+    else:
+        lengths = seqs.astype(str).str.len().to_numpy()
+    hist = (
+        pd.DataFrame({"Run": df["Run"].to_numpy() if not hasattr(df["Run"], "cat") else df["Run"].cat.codes.to_numpy(), "length": lengths})
+        .query("length >= 0")
+        .groupby(["Run", "length"], sort=True)
+        .size()
+    )
+    run_labels = df["Run"].cat.categories if hasattr(df["Run"], "cat") else None
     plot_data = {}
-    for run, group in df_sub.groupby("Run", observed=True):
-        stats_dict = group["length"].value_counts().sort_index().to_dict()
-        plot_data[run] = stats_dict
-
+    for (run, length), count in hist.items():
+        key = run_labels[run] if run_labels is not None else run
+        plot_data.setdefault(key, {})[int(length)] = int(count)
     return plot_data
-
-
-## Removed draw_dia_heatmap wrapper; call cal_dia_heatmap and dia_plots.draw_heatmap directly.
-
 
 def draw_dia_intensitys(sub_section, report_df, sdrf_file_df):
     """Draw the precursor intensity distribution and standard-deviation plots."""

--- a/pmultiqc/modules/common/dia_utils.py
+++ b/pmultiqc/modules/common/dia_utils.py
@@ -1,5 +1,6 @@
 import itertools
 import numpy as np
+from pmultiqc.modules.common.plots.general import run_to_sample_codes
 import pandas as pd
 import re
 from collections import OrderedDict
@@ -315,25 +316,6 @@ def _process_run_data(df, ms_with_psm, quantms_modified, sdrf_file_df):
     )
 
     return cal_num_table_data
-
-
-def run_to_sample_codes(runs: pd.Series, file_df: pd.DataFrame) -> pd.Series:
-    """Sample id per row from the Run column, without materialising strings.
-
-    Merging the report with the SDRF sample table on ``Run`` was measured to be
-    the largest transient in the summary: it upcasts the categorical key to
-    object for every row (231 M on PXD030304) and adds an object Sample column.
-    Mapping through the category codes touches one small array instead.
-    Rows whose run is not in ``file_df`` get NaN.
-    """
-    run_to_sample = file_df[["Run", "Sample"]].drop_duplicates().set_index("Run")["Sample"]
-    run_to_sample.index = run_to_sample.index.astype(str)
-    if isinstance(runs.dtype, pd.CategoricalDtype):
-        per_category = run_to_sample.reindex(runs.cat.categories.astype(str)).to_numpy(dtype="float64", na_value=np.nan)
-        codes = runs.cat.codes.to_numpy()
-        values = np.where(codes >= 0, per_category[np.clip(codes, 0, None)], np.nan)
-        return pd.Series(values, index=runs.index)
-    return runs.astype(str).map(run_to_sample).astype("float64")
 
 
 def _is_modified(sequences: pd.Series) -> pd.Series:

--- a/pmultiqc/modules/common/dia_utils.py
+++ b/pmultiqc/modules/common/dia_utils.py
@@ -317,6 +317,25 @@ def _process_run_data(df, ms_with_psm, quantms_modified, sdrf_file_df):
     return cal_num_table_data
 
 
+def run_to_sample_codes(runs: pd.Series, file_df: pd.DataFrame) -> pd.Series:
+    """Sample id per row from the Run column, without materialising strings.
+
+    Merging the report with the SDRF sample table on ``Run`` was measured to be
+    the largest transient in the summary: it upcasts the categorical key to
+    object for every row (231 M on PXD030304) and adds an object Sample column.
+    Mapping through the category codes touches one small array instead.
+    Rows whose run is not in ``file_df`` get NaN.
+    """
+    run_to_sample = file_df[["Run", "Sample"]].drop_duplicates().set_index("Run")["Sample"]
+    run_to_sample.index = run_to_sample.index.astype(str)
+    if isinstance(runs.dtype, pd.CategoricalDtype):
+        per_category = run_to_sample.reindex(runs.cat.categories.astype(str)).to_numpy(dtype="float64", na_value=np.nan)
+        codes = runs.cat.codes.to_numpy()
+        values = np.where(codes >= 0, per_category[np.clip(codes, 0, None)], np.nan)
+        return pd.Series(values, index=runs.index)
+    return runs.astype(str).map(run_to_sample).astype("float64")
+
+
 def _is_modified(sequences: pd.Series) -> pd.Series:
     """True where the peptidoform carries a modification (a parenthesised group)."""
     if isinstance(sequences.dtype, pd.CategoricalDtype):
@@ -346,8 +365,7 @@ def _sample_identification_counts(report_data: pd.DataFrame, file_df: pd.DataFra
     """Counts per sample, de-duplicated across the sample's runs (what the per-run sets used to feed)."""
     if file_df is None or file_df.empty or not {"Sample", "Run"} <= set(file_df.columns):
         return dict()
-    run_to_sample = file_df[["Run", "Sample"]].drop_duplicates().set_index("Run")["Sample"].astype(int)
-    sample = report_data["Run"].astype(str).map(run_to_sample)
+    sample = run_to_sample_codes(report_data["Run"], file_df)
     keep = sample.notna()
     if not keep.any():
         return dict()
@@ -1070,14 +1088,14 @@ def dia_sample_level_modifications(df, sdrf_file_df):
     if sdrf_file_df is None or sdrf_file_df.empty:
         return {}
 
-    report_data = df.copy()
-
-    report_data = report_data.merge(
-        right=sdrf_file_df[["Sample", "Run"]].drop_duplicates(),
-        on="Run"
-    )
-
-    report_data["Sample"] = report_data["Sample"].astype(int)
+    # No merge: it upcast the categorical Run key to object for every row and
+    # was the transient that OOM-killed the summary in this stage (#717).
+    sample = run_to_sample_codes(df["Run"], sdrf_file_df)
+    keep = sample.notna()
+    # Keep Run: drop_duplicates below counts a peptidoform once per run within a
+    # sample, as the merge-based version did.
+    report_data = df.loc[keep, ["Run", "Modified.Sequence", "Modifications", "Protein.Group"]].copy()
+    report_data["Sample"] = sample[keep].astype(int).to_numpy()
 
     mod_plot = dict()
     for sample, group in report_data.groupby("Sample", sort=True, observed=True):

--- a/pmultiqc/modules/common/plots/dia.py
+++ b/pmultiqc/modules/common/plots/dia.py
@@ -12,6 +12,7 @@ from pmultiqc.modules.common.plots.general import (
     plot_data_check
 )
 from pmultiqc.modules.common.stats import cal_delta_mass_dict
+from pmultiqc.modules.common.dia_utils import run_to_sample_codes
 from pmultiqc.modules.core.section_groups import add_sub_section
 from pmultiqc.modules.common.plots import dia as dia_plots
 from pmultiqc.modules.common.common_utils import group_charge
@@ -90,7 +91,7 @@ def draw_dia_intensity_dis(sub_section, df, sdrf_file_df):
             # were built twice (by run, by sample), both alive at once: the
             # spike that OOM-killed the summary at 72 GB (bigbio/pmultiqc#717).
             # Map Run->Sample on the key and aggregate.
-            sample = df["Run"].astype(object).map(run_to_sample)
+            sample = run_to_sample_codes(df["Run"], sdrf_file_df)
             keep = sample.notna()
             by_sample = df.loc[keep, ["log_intensity"]].assign(Sample=sample[keep].astype(int).to_numpy())
             box_data = [

--- a/pmultiqc/modules/common/plots/dia.py
+++ b/pmultiqc/modules/common/plots/dia.py
@@ -164,6 +164,9 @@ def draw_dia_ms1_area(sub_section, df):
         "save_data_file": False,
     }
 
+    # 5,798 runs x raw MS1 areas is >4 GiB of serialised points and panics polars
+    # (bigbio/pmultiqc#717). Above the flat threshold hand MultiQC the box statistics.
+    box_data = summarise_box_data(box_data)
     box_html = box.plot(list_of_data_by_sample=box_data, pconfig=draw_config)
 
     # box_html.flat
@@ -312,6 +315,8 @@ def draw_dia_intensity_std(sub_section, df, sdrf_file_df):
         "save_data_file": False,
     }
 
+    # Same failure mode as draw_dia_ms1_area: 42.7 M points on the big DIA run.
+    box_data = summarise_box_data(box_data)
     box_html = box.plot(
         list_of_data_by_sample=box_data,
         pconfig=draw_box_config,

--- a/pmultiqc/modules/common/plots/dia.py
+++ b/pmultiqc/modules/common/plots/dia.py
@@ -12,7 +12,6 @@ from pmultiqc.modules.common.plots.general import (
     plot_data_check
 )
 from pmultiqc.modules.common.stats import cal_delta_mass_dict
-from pmultiqc.modules.common.dia_utils import run_to_sample_codes
 from pmultiqc.modules.core.section_groups import add_sub_section
 from pmultiqc.modules.common.plots import dia as dia_plots
 from pmultiqc.modules.common.common_utils import group_charge

--- a/pmultiqc/modules/common/plots/dia.py
+++ b/pmultiqc/modules/common/plots/dia.py
@@ -5,6 +5,9 @@ from multiqc.plots import heatmap, box, bargraph, linegraph
 
 from pmultiqc.modules.common.plots.general import (
     summarise_box_data,
+    box_stats_by_group,
+    run_to_sample_codes,
+    FLAT_THRESHOLD,
     plot_html_check,
     plot_data_check
 )
@@ -75,38 +78,50 @@ def draw_heatmap(sub_section, hm_colors, heatmap_data):
 # Intensity Distribution
 def draw_dia_intensity_dis(sub_section, df, sdrf_file_df):
 
-    df_sub = df[["Run", "Modified.Sequence", "Protein.Group", "log_intensity"]].copy()
+    large = len(df) >= FLAT_THRESHOLD
 
     if not sdrf_file_df.empty:
-
-        df_sub = df_sub.merge(
-            sdrf_file_df[["Sample", "Run"]].drop_duplicates(),
-            on="Run"
+        run_to_sample = (
+            sdrf_file_df[["Sample", "Run"]].drop_duplicates().set_index("Run")["Sample"].astype(int)
         )
-
-        df_sub["Sample"] = df_sub["Sample"].astype(int)
-
-        box_data = [
-            {
-                (
-                    f"Sample {str(run)}"
-                    if data_type == "Sample"
-                    else str(run)
-                ): group["log_intensity"].dropna().tolist()
-                for run, group in df_sub.groupby(data_type, sort=True, observed=True)
-            }
-            for data_type in ["Run", "Sample"]
-        ]
+        if large:
+            # No merge and no per-group lists. On PXD030304 the merge upcast the
+            # categorical Run key to object for 231 M rows and the float lists
+            # were built twice (by run, by sample), both alive at once: the
+            # spike that OOM-killed the summary at 72 GB (bigbio/pmultiqc#717).
+            # Map Run->Sample on the key and aggregate.
+            sample = df["Run"].astype(object).map(run_to_sample)
+            keep = sample.notna()
+            by_sample = df.loc[keep, ["log_intensity"]].assign(Sample=sample[keep].astype(int).to_numpy())
+            box_data = [
+                box_stats_by_group(df, "log_intensity", "Run"),
+                box_stats_by_group(by_sample, "log_intensity", "Sample", label=lambda k: f"Sample {int(k)}"),
+            ]
+        else:
+            df_sub = df[["Run", "log_intensity"]].copy()
+            df_sub["Sample"] = df_sub["Run"].astype(object).map(run_to_sample)
+            df_sub = df_sub[df_sub["Sample"].notna()]
+            df_sub["Sample"] = df_sub["Sample"].astype(int)
+            box_data = [
+                {
+                    (f"Sample {str(run)}" if data_type == "Sample" else str(run)): group["log_intensity"].dropna().tolist()
+                    for run, group in df_sub.groupby(data_type, sort=True, observed=True)
+                }
+                for data_type in ["Run", "Sample"]
+            ]
 
         plot_label = ["by Run", "by Sample"]
 
     else:
-        box_data = [
-            {
-                str(run): group["log_intensity"].dropna().tolist()
-                for run, group in df.groupby("Run", observed=True)
-            }
-        ]
+        if large:
+            box_data = [box_stats_by_group(df, "log_intensity", "Run")]
+        else:
+            box_data = [
+                {
+                    str(run): group["log_intensity"].dropna().tolist()
+                    for run, group in df.groupby("Run", observed=True)
+                }
+            ]
         plot_label = ["by Run"]
 
     draw_config = {
@@ -149,10 +164,14 @@ def draw_dia_intensity_dis(sub_section, df, sdrf_file_df):
 # Ms1.Area non-normalised MS1 peak area
 def draw_dia_ms1_area(sub_section, df):
 
-    box_data = {
-        str(run): group["log_ms1_area"].dropna().tolist()
-        for run, group in df.groupby("Run", observed=True)
-    }
+    if len(df) >= FLAT_THRESHOLD:
+        # No per-run Python lists on large reports (bigbio/pmultiqc#717).
+        box_data = box_stats_by_group(df, "log_ms1_area", "Run")
+    else:
+        box_data = {
+            str(run): group["log_ms1_area"].dropna().tolist()
+            for run, group in df.groupby("Run", observed=True)
+        }
 
     draw_config = {
         "id": "ms1_area_distribution_box",

--- a/pmultiqc/modules/common/plots/general.py
+++ b/pmultiqc/modules/common/plots/general.py
@@ -524,3 +524,46 @@ def run_to_sample_codes(runs: pd.Series, file_df: pd.DataFrame) -> pd.Series:
         values = np.where(codes >= 0, per_category[np.clip(codes, 0, None)], np.nan)
         return pd.Series(values, index=runs.index)
     return runs.astype(str).map(run_to_sample).astype("float64")
+
+
+def box_stats_by_group(df, value_col, key, whisker_iqr=1.5, label=str):
+    """Box statistics per group without materialising per-group Python lists.
+
+    Same numbers as ``summarise_box_data`` applied to ``{group: values.tolist()}``
+    -- percentile q1/median/q3, Tukey whiskers (min/max within q1-1.5*IQR ..
+    q3+1.5*IQR, or the plain min/max when IQR is 0), and the mean -- computed
+    with vectorised groupbys. On PXD030304 the list form was 231 M Python
+    floats built twice (by run and by sample) on top of a merge that upcast the
+    categorical run key to object: the spike that OOM-killed the summary at
+    72 GB (bigbio/pmultiqc#717).
+
+    Returns ``{label(group): {min, q1, median, q3, max, mean}}`` for groups
+    with at least one finite value.
+    """
+    values = pd.to_numeric(df[value_col], errors="coerce")
+    finite = np.isfinite(values.to_numpy(dtype="float64", na_value=np.nan))
+    sub = pd.DataFrame({"k": df[key].to_numpy() if not hasattr(df[key], "cat") else df[key].astype(object).to_numpy(),
+                        "v": values.to_numpy(dtype="float64", na_value=np.nan)})[finite]
+    if sub.empty:
+        return {}
+    g = sub.groupby("k", sort=True)
+    q = g["v"].quantile([0.25, 0.5, 0.75]).unstack()
+    q.columns = ["q1", "median", "q3"]
+    stats = q.assign(mean=g["v"].mean(), lo=g["v"].min(), hi=g["v"].max())
+    iqr = stats["q3"] - stats["q1"]
+    low_bound = (stats["q1"] - whisker_iqr * iqr)
+    high_bound = (stats["q3"] + whisker_iqr * iqr)
+    lb = sub["k"].map(low_bound).to_numpy(); hb = sub["k"].map(high_bound).to_numpy()
+    v = sub["v"].to_numpy()
+    fenced_min = sub[v >= lb].groupby("k")["v"].min()
+    fenced_max = sub[v <= hb].groupby("k")["v"].max()
+    use_fence = iqr > 0
+    stats["min"] = np.where(use_fence, fenced_min.reindex(stats.index), stats["lo"])
+    stats["max"] = np.where(use_fence, fenced_max.reindex(stats.index), stats["hi"])
+    out = {}
+    for k, row in stats.iterrows():
+        out[label(k)] = {
+            "min": float(row["min"]), "q1": float(row["q1"]), "median": float(row["median"]),
+            "q3": float(row["q3"]), "max": float(row["max"]), "mean": float(row["mean"]),
+        }
+    return out

--- a/pmultiqc/modules/common/plots/general.py
+++ b/pmultiqc/modules/common/plots/general.py
@@ -505,3 +505,22 @@ def summarise_box_data(plot_data, whisker_iqr=1.5, max_points=None):
         summarised.append(out)
 
     return summarised if was_list else summarised[0]
+
+
+def run_to_sample_codes(runs: pd.Series, file_df: pd.DataFrame) -> pd.Series:
+    """Sample id per row from the Run column, without materialising strings.
+
+    Merging the report with the SDRF sample table on ``Run`` was measured to be
+    the largest transient in the summary: it upcasts the categorical key to
+    object for every row (231 M on PXD030304) and adds an object Sample column.
+    Mapping through the category codes touches one small array instead.
+    Rows whose run is not in ``file_df`` get NaN.
+    """
+    run_to_sample = file_df[["Run", "Sample"]].drop_duplicates().set_index("Run")["Sample"]
+    run_to_sample.index = run_to_sample.index.astype(str)
+    if isinstance(runs.dtype, pd.CategoricalDtype):
+        per_category = run_to_sample.reindex(runs.cat.categories.astype(str)).to_numpy(dtype="float64", na_value=np.nan)
+        codes = runs.cat.codes.to_numpy()
+        values = np.where(codes >= 0, per_category[np.clip(codes, 0, None)], np.nan)
+        return pd.Series(values, index=runs.index)
+    return runs.astype(str).map(run_to_sample).astype("float64")

--- a/pmultiqc/modules/quantms/quantms.py
+++ b/pmultiqc/modules/quantms/quantms.py
@@ -664,8 +664,15 @@ class QuantMSModule(BasePMultiqcModule):
             name="draw_quantms_time_section"
         )
 
-        if self.qpx_source is None and self.msstats_input_valid:
+        # parse_msstats_input only builds the peptide/protein quantification
+        # tables. Do not read the MSstats input when tables are disabled: on
+        # PXD030304 it is a 20.6 GiB, 231 M-row CSV that pd.read_csv turned
+        # into 93 GB of Python strings for output that was then discarded
+        # (bigbio/pmultiqc#717).
+        if self.qpx_source is None and self.msstats_input_valid and not config.kwargs.get("disable_table", False):
             self.parse_msstats_input()
+        elif self.msstats_input_valid and config.kwargs.get("disable_table", False):
+            log.info("Tables disabled; skipping the MSstats input parse.")
         quant_method = config.kwargs.get("quantification_method", None)
 
         if (

--- a/tests/test_dia_box_plots.py
+++ b/tests/test_dia_box_plots.py
@@ -1,0 +1,57 @@
+"""DIA box plots must hand MultiQC summary statistics, not raw points, on large runs (#717).
+
+On PXD030304 (5,798 runs) draw_dia_ms1_area serialised every raw MS1 area into the
+box plot and polars panicked on a >4 GiB buffer; draw_dia_intensity_std carried
+42.7 M points. Above the flat threshold both must pass {min,q1,median,q3,max,mean}.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pmultiqc.modules.common.plots import dia as dia_plots
+from pmultiqc.modules.common.plots import general
+
+
+@pytest.fixture
+def capture_box(monkeypatch):
+    seen = []
+    monkeypatch.setattr(dia_plots.box, "plot", lambda list_of_data_by_sample, pconfig=None: seen.append(list_of_data_by_sample) or "html")
+    monkeypatch.setattr(dia_plots, "add_sub_section", lambda **kw: None)
+    monkeypatch.setattr(dia_plots, "plot_html_check", lambda h: h, raising=False)
+    return seen
+
+
+def _big_ms1(n_runs=20, per_run=None):
+    per_run = per_run or (general.FLAT_THRESHOLD // n_runs + 1)
+    rng = np.random.default_rng(0)
+    return pd.DataFrame({
+        "Run": np.repeat([f"run{i}" for i in range(n_runs)], per_run),
+        "log_ms1_area": rng.normal(20, 2, n_runs * per_run),
+    })
+
+
+def test_ms1_area_uses_summary_stats_above_threshold(capture_box):
+    dia_plots.draw_dia_ms1_area(None, _big_ms1())
+    (data,) = capture_box
+    assert data, "box.plot received no data"
+    for run, stats in data.items():
+        assert isinstance(stats, dict), f"{run}: raw list reached box.plot"
+        assert {"min", "q1", "median", "q3", "max", "mean"} <= set(stats)
+
+
+def test_ms1_area_keeps_raw_points_below_threshold(capture_box):
+    dia_plots.draw_dia_ms1_area(None, _big_ms1(n_runs=2, per_run=10))
+    (data,) = capture_box
+    assert all(isinstance(v, list) for v in data.values()), "small reports should keep raw points"
+
+
+def test_intensity_std_uses_summary_stats_above_threshold(capture_box, monkeypatch):
+    n = general.FLAT_THRESHOLD + 10
+    fake = [{"Sample 1": list(np.linspace(0, 1, n))}]
+    monkeypatch.setattr(dia_plots, "calculate_dia_intensity_std", lambda df, sdrf: fake)
+    dia_plots.draw_dia_intensity_std(None, pd.DataFrame(), pd.DataFrame())
+    (data,) = capture_box
+    ds = data[0] if isinstance(data, list) else data
+    assert isinstance(ds["Sample 1"], dict)
+    assert {"min", "q1", "median", "q3", "max", "mean"} <= set(ds["Sample 1"])

--- a/tests/test_dia_box_plots.py
+++ b/tests/test_dia_box_plots.py
@@ -55,3 +55,36 @@ def test_intensity_std_uses_summary_stats_above_threshold(capture_box, monkeypat
     ds = data[0] if isinstance(data, list) else data
     assert isinstance(ds["Sample 1"], dict)
     assert {"min", "q1", "median", "q3", "max", "mean"} <= set(ds["Sample 1"])
+
+
+def test_box_stats_by_group_matches_summarise_box_data():
+    """Vectorised per-group statistics must equal the list-based summary (#717)."""
+    rng = np.random.default_rng(7)
+    n = general.FLAT_THRESHOLD + 500
+    keys = rng.choice([f"r{i}" for i in range(12)], n)
+    vals = np.concatenate([rng.normal(20, 2, n - 40), np.full(20, 20.0), rng.normal(20, 40, 20)])  # ties + outliers
+    vals[:5] = np.nan
+    df = pd.DataFrame({"Run": pd.Categorical(keys), "x": vals})
+    lists = {str(k): g["x"].dropna().tolist() for k, g in df.groupby("Run", observed=True)}
+    expected = general.summarise_box_data(lists)
+    got = general.box_stats_by_group(df, "x", "Run")
+    assert got.keys() == expected.keys()
+    for k in expected:
+        for stat in ("min", "q1", "median", "q3", "max", "mean"):
+            assert np.isclose(got[k][stat], expected[k][stat]), (k, stat, got[k][stat], expected[k][stat])
+
+
+def test_intensity_dis_by_sample_without_merge(capture_box):
+    n = general.FLAT_THRESHOLD + 10
+    df = pd.DataFrame({
+        "Run": pd.Categorical(np.repeat(["a", "b"], n // 2)),
+        "Modified.Sequence": pd.Categorical(["P"] * n),
+        "Protein.Group": pd.Categorical(["G"] * n),
+        "log_intensity": np.linspace(10, 30, n),
+    })
+    sdrf = pd.DataFrame({"Run": ["a", "b"], "Sample": [1, 1]})
+    dia_plots.draw_dia_intensity_dis(None, df, sdrf)
+    (data,) = capture_box
+    assert isinstance(data, list) and len(data) == 2
+    assert set(data[0]) == {"a", "b"} and set(data[1]) == {"Sample 1"}
+    assert all(isinstance(v, dict) for ds in data for v in ds.values())

--- a/tests/test_diann_reader.py
+++ b/tests/test_diann_reader.py
@@ -265,3 +265,24 @@ def test_dia_utils_imports_cleanly_first():
     code = "import pmultiqc.modules.common.dia_utils as d; import pmultiqc.modules.common.plots.dia; print(callable(d.run_to_sample_codes))"
     out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
     assert out.returncode == 0 and out.stdout.strip() == "True", out.stderr[-800:]
+
+
+def test_peptide_length_matches_string_implementation():
+    import numpy as np
+    from pmultiqc.modules.common import dia_utils
+
+    rng = np.random.default_rng(11)
+    n = 5000
+    seqs = [("PEPTIDE" * rng.integers(1, 4))[: rng.integers(5, 20)] for _ in range(60)]
+    df = pd.DataFrame({
+        "Run": pd.Categorical(rng.choice([f"r{i}" for i in range(7)], n)),
+        "Stripped.Sequence": pd.Categorical(rng.choice(seqs, n)),
+    })
+    # reference: the previous implementation
+    ref_sub = df[["Run", "Stripped.Sequence"]].copy()
+    ref_sub["length"] = ref_sub["Stripped.Sequence"].astype(str).str.len()
+    expected = {run: g["length"].value_counts().sort_index().to_dict() for run, g in ref_sub.groupby("Run", observed=True)}
+    got = dia_utils._get_peptide_length(df)
+    assert set(got) == set(expected)
+    for run in expected:
+        assert {int(k): int(v) for k, v in got[run].items()} == {int(k): int(v) for k, v in expected[run].items()}, run

--- a/tests/test_diann_reader.py
+++ b/tests/test_diann_reader.py
@@ -229,3 +229,31 @@ def test_identification_counts_match_the_set_based_logic():
     old_sample = cal_num_table_at_sample(file_df, data_per_run)
     assert dia_utils._run_identification_counts(df) == old_run
     assert dia_utils._sample_identification_counts(df, file_df) == old_sample
+
+
+def test_sample_level_modifications_without_merge_matches_merge_reference():
+    import numpy as np
+    from pmultiqc.modules.common import dia_utils
+    from pmultiqc.modules.common.common_utils import summarize_modifications
+
+    rng = np.random.default_rng(5)
+    n = 4000
+    runs = [f"run{i}" for i in range(6)]
+    df = pd.DataFrame({
+        "Run": pd.Categorical(rng.choice(runs, n)),
+        "Modified.Sequence": pd.Categorical(rng.choice([f"PEP{i}K" for i in range(80)], n)),
+        "Modifications": pd.Categorical(rng.choice(["Unmodified", "Oxidation", "Carbamidomethyl,Oxidation"], n)),
+        "Protein.Group": pd.Categorical(rng.choice([f"P{i}" for i in range(10)], n)),
+    })
+    file_df = pd.DataFrame({"Run": runs[:5], "Sample": [1, 1, 2, 2, 3]})  # run5 unmapped
+    ref = df.merge(file_df[["Sample", "Run"]].drop_duplicates(), on="Run")
+    ref["Sample"] = ref["Sample"].astype(int)
+    expected = {f"Sample {s}": summarize_modifications(g.drop_duplicates())[0] for s, g in ref.groupby("Sample", sort=True)}
+    got = dia_utils.dia_sample_level_modifications(df, file_df)
+    assert got.keys() == expected.keys()
+    for k in expected:
+        assert got[k].keys() == expected[k].keys()
+        for m in expected[k]:
+            assert np.isclose(got[k][m], expected[k][m]), (k, m)
+    codes = dia_utils.run_to_sample_codes(df["Run"], file_df)
+    assert codes.isna().sum() == (df["Run"].astype(str) == "run5").sum()

--- a/tests/test_diann_reader.py
+++ b/tests/test_diann_reader.py
@@ -257,3 +257,11 @@ def test_sample_level_modifications_without_merge_matches_merge_reference():
             assert np.isclose(got[k][m], expected[k][m]), (k, m)
     codes = dia_utils.run_to_sample_codes(df["Run"], file_df)
     assert codes.isna().sum() == (df["Run"].astype(str) == "run5").sum()
+
+
+def test_dia_utils_imports_cleanly_first():
+    """multiqc imports dia_utils before plots.dia; a cycle there skips the whole module (#717)."""
+    import subprocess, sys
+    code = "import pmultiqc.modules.common.dia_utils as d; import pmultiqc.modules.common.plots.dia; print(callable(d.run_to_sample_codes))"
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert out.returncode == 0 and out.stdout.strip() == "True", out.stderr[-800:]

--- a/tests/test_msstats_gate.py
+++ b/tests/test_msstats_gate.py
@@ -1,0 +1,20 @@
+"""The MSstats input parse only feeds the quantification tables; skip it when tables are disabled (#717)."""
+
+import ast
+from pathlib import Path
+
+import pmultiqc.modules.quantms.quantms as qm
+
+
+def test_msstats_parse_is_gated_on_disable_table():
+    src = Path(qm.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    gate_found = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.If):
+            cond = ast.unparse(node.test)
+            body = ast.unparse(node)
+            if "msstats_input_valid" in cond and "parse_msstats_input()" in body:
+                assert "disable_table" in cond, f"MSstats parse not gated on disable_table: {cond}"
+                gate_found = True
+    assert gate_found, "could not find the msstats parse call site"


### PR DESCRIPTION
#722 was merged at `e6f2eb0`; four fixes pushed to its branch afterwards never reached `dev`, and #724 was merged into #722's branch rather than `dev` — a later force-push of that branch discarded the merge commit. So `dev` (and the release PR #721) carries a **partial** #722 and no #724.

This branch is the exact stack that was verified on PXD030304 at the pipeline's 72 GB (job 36442153: exit 0, peak 68.0 GiB, module present, 347 sections). Eight commits, all on `dev`'s current head:

**Late #722 commits**
- `d8199a7` sample-level modifications without the 231 M-row merge (`run_to_sample_codes`)
- `f4d9f71` `run_to_sample_codes` lives in `plots.general` — avoids an import cycle that made MultiQC skip the whole QuantMS module
- `6edeb94` peptide length histogram without materialising the sequences
- `3c981d7` **do not parse the MSstats input when tables are disabled** — the last cliff (20.6 GiB CSV → 93 GB)

**#724**
- `dfb038a` box statistics instead of raw points for MS1 area and intensity std (polars panic at 5,798 runs)
- `187a5b8`, `c60d5a6`, `e08f531` import/mapping follow-ups

Without these, `dev` still: panics in polars on large DIA (raw-point box plots), merges the full frame with the SDRF in the sample-level modifications, and parses the MSstats CSV even with `--disable-table`. 206 tests pass. Full trail on #717.

**#721 (dev → main) should wait for this.**